### PR TITLE
fix(build): Fix `make clean` for worker builds

### DIFF
--- a/src/worker/bddisasm/Makefile
+++ b/src/worker/bddisasm/Makefile
@@ -13,4 +13,5 @@ bddisasm.so: bddisasm/bin/x64/Release/bddisasm.a bddisasm.o
 
 .PHONY: clean
 clean:
+	$(MAKE) -C bddisasm clean
 	rm -rf *.o *.so

--- a/src/worker/udis86/Makefile
+++ b/src/worker/udis86/Makefile
@@ -23,3 +23,5 @@ udis86.o: udis86/build/lib/libudis86.so udis86.c
 
 .PHONY: clean
 clean:
+	make -C udis86 clean
+	rm -rf *.o *.so

--- a/src/worker/xed/Makefile
+++ b/src/worker/xed/Makefile
@@ -20,4 +20,5 @@ xed.o: xed/kits/xed-mishegos/libxed.so xed.c
 
 .PHONY: clean
 clean:
+	cd xed && python3 ./mfile.py clean && rm -rf kits
 	rm -rf *.o *.so


### PR DESCRIPTION
This should make the top-level `make clean` slightly more reliable.