### PR TITLE
Add iced disassembler worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.so
 src/mishegos/mishegos
 src/worker/worker
+src/mish2jsonl/mish2jsonl
+Cargo.lock
+target/

--- a/.gitmodules
+++ b/.gitmodules
@@ -23,3 +23,6 @@
 	path = src/worker/bddisasm/bddisasm
 	url = https://github.com/bitdefender/bddisasm.git
 	branch = master
+[submodule "src/worker/iced/iced"]
+	path = src/worker/iced/iced
+	url = https://github.com/0xd4d/iced.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,14 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y \
         autotools-dev \
         autoconf \
         libtool \
-        git
+        git \
+        curl \
+        llvm-dev \
+        libclang-dev \
+        clang
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 WORKDIR /app/mishegos
 COPY ./ .

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ export CPPFLAGS :=
 export CXXFLAGS := \
 	-std=c++11 -Wall -Werror -pthread \
 	-I$(shell pwd)/src/include
+export RUSTFLAGS := -D warnings
+export RUST_BINDGEN_CLANG_ARGS := \
+	-I$(shell pwd)/src/include
 
 ALL_SRCS := $(shell \
 	find . -type f \

--- a/src/worker/Makefile
+++ b/src/worker/Makefile
@@ -5,7 +5,8 @@ WORKERS = bfd \
 	udis86 \
 	xed \
 	zydis \
-	bddisasm
+	bddisasm \
+	iced
 
 .PHONY: all
 all: worker $(WORKERS)

--- a/src/worker/iced/Cargo.toml
+++ b/src/worker/iced/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "iced"
+version = "1.0.0"
+authors = ["mishegos"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies.iced-x86]
+default-features = false
+features = ["std", "decoder", "intel"]
+path = "./iced/src/rust/iced-x86"
+
+[build-dependencies]
+bindgen = "*"
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = 3

--- a/src/worker/iced/Makefile
+++ b/src/worker/iced/Makefile
@@ -1,0 +1,14 @@
+.PHONY: all
+all: iced.so
+
+iced.so: target/release/libiced.so
+	cp target/release/libiced.so $@
+
+target/release/libiced.so:
+	cargo test --release
+	cargo build --release
+
+.PHONY: clean
+clean:
+	cargo clean --release
+	rm -f *.so

--- a/src/worker/iced/build.rs
+++ b/src/worker/iced/build.rs
@@ -1,0 +1,20 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=wrapper.h");
+
+    let clang_args = env::var("RUST_BINDGEN_CLANG_ARGS").unwrap();
+    let bindings = bindgen::Builder::default()
+        .header("wrapper.h")
+        .clang_args(clang_args.split_ascii_whitespace())
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/src/worker/iced/src/lib.rs
+++ b/src/worker/iced/src/lib.rs
@@ -1,0 +1,90 @@
+mod mishegos;
+
+use iced_x86::*;
+use mishegos::{
+    decode_result, decode_status_S_FAILURE, decode_status_S_PARTIAL, decode_status_S_SUCCESS,
+};
+
+// This is pretty ugly and assumes sizeof(char) == 1
+#[no_mangle]
+pub static mut worker_name: *const std::os::raw::c_char =
+    WORKER_NAME.as_ptr() as *const std::os::raw::c_char;
+static WORKER_NAME: &str = "iced\0";
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn try_decode(result: *mut decode_result, raw_insn: *const u8, length: u8) {
+    assert!(!result.is_null());
+    assert!(!raw_insn.is_null());
+    let data = std::slice::from_raw_parts(raw_insn, length as usize);
+    let result = &mut *result;
+    let error = match try_decode_safe(64, 0, data) {
+        Err(error) => error,
+        Ok((instr_len, output)) => {
+            result.ndecoded = instr_len as u16;
+            assert_eq!(std::mem::size_of::<std::os::raw::c_char>(), 1);
+            if output.len() > result.result.len() {
+                decode_status_S_FAILURE
+            } else {
+                std::ptr::copy(
+                    output.as_ptr(),
+                    result.result.as_mut_ptr() as *mut u8,
+                    output.len(),
+                );
+                result.len = output.len() as u16;
+                decode_status_S_SUCCESS
+            }
+        }
+    };
+    result.status = error;
+}
+
+fn try_decode_safe(bitness: u32, ip: u64, data: &[u8]) -> Result<(usize, String), u32> {
+    // Don't enable old instructions not supported by current CPUs
+    // Don't enable deprecated MPX instructions
+    // Don't enable LOCK MOV CR (only supported by some AMD CPUs)
+    const DECODER_OPTIONS: u32 = DecoderOptions::NO_LOCK_MOV_CR;
+
+    let mut decoder = Decoder::new(bitness, data, DECODER_OPTIONS);
+    decoder.set_ip(ip);
+    let instr = decoder.decode();
+
+    if instr.is_invalid() {
+        match decoder.last_error() {
+            DecoderError::None => unreachable!(),
+            DecoderError::NoMoreBytes => Err(decode_status_S_PARTIAL),
+            _ => Err(decode_status_S_FAILURE),
+        }
+    } else {
+        let mut formatter = IntelFormatter::new();
+        // Try to match default XED output
+        formatter.options_mut().set_hex_suffix("");
+        formatter.options_mut().set_hex_prefix("0x");
+        formatter.options_mut().set_uppercase_hex(false);
+        formatter
+            .options_mut()
+            .set_space_after_operand_separator(true);
+        formatter
+            .options_mut()
+            .set_memory_size_options(MemorySizeOptions::Always);
+        formatter.options_mut().set_always_show_scale(true);
+        formatter.options_mut().set_rip_relative_addresses(true);
+        formatter
+            .options_mut()
+            .set_small_hex_numbers_in_decimal(false);
+        formatter.options_mut().set_cc_ge(CC_ge::nl);
+        formatter.options_mut().set_cc_a(CC_a::nbe);
+        formatter.options_mut().set_cc_e(CC_e::z);
+        formatter.options_mut().set_cc_ne(CC_ne::nz);
+        formatter.options_mut().set_cc_ae(CC_ae::nb);
+        formatter.options_mut().set_cc_g(CC_g::nle);
+        formatter.options_mut().set_show_branch_size(false);
+        formatter.options_mut().set_branch_leading_zeroes(false);
+        formatter.options_mut().set_use_pseudo_ops(false);
+
+        let mut output = String::new();
+        formatter.format(&instr, &mut output);
+
+        Ok((instr.len(), output))
+    }
+}

--- a/src/worker/iced/src/mishegos.rs
+++ b/src/worker/iced/src/mishegos.rs
@@ -1,0 +1,10 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(dead_code)]
+// "warning: `extern` block uses type `u128`, which is not FFI-safe"
+// "note: 128-bit integers don't currently have a known stable ABI"
+#![allow(improper_ctypes)]
+#![allow(clippy::redundant_static_lifetimes)]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/worker/iced/wrapper.h
+++ b/src/worker/iced/wrapper.h
@@ -1,0 +1,1 @@
+#include "../worker.h"

--- a/workers.spec
+++ b/workers.spec
@@ -6,3 +6,4 @@
 ./src/worker/xed/xed.so
 ./src/worker/zydis/zydis.so
 ./src/worker/bddisasm/bddisasm.so
+./src/worker/iced/iced.so


### PR DESCRIPTION
This PR adds an iced worker (Rust), requested by https://github.com/0xd4d/iced/issues/93

It's written in Rust so Rust dependencies were added. `build.rs` uses `bindgen` which depends on a few clang packages.

https://github.com/trailofbits/mishegos/issues/3