### PR TITLE
fix(build): temporarily disable the DynamoRIO worker

### DIFF
--- a/src/worker/Makefile
+++ b/src/worker/Makefile
@@ -1,6 +1,5 @@
 WORKERS = bfd \
 	capstone \
-	dynamorio \
 	fadec \
 	udis86 \
 	xed \

--- a/workers.spec
+++ b/workers.spec
@@ -1,6 +1,6 @@
 ./src/worker/bfd/bfd.so
 ./src/worker/capstone/capstone.so
-./src/worker/dynamorio/dynamorio.so
+#./src/worker/dynamorio/dynamorio.so
 ./src/worker/fadec/fadec.so
 ./src/worker/udis86/udis86.so
 ./src/worker/xed/xed.so


### PR DESCRIPTION
See:

* https://github.com/trailofbits/mishegos/pull/252#issuecomment-738061853
* https://github.com/actions/virtual-environments/pull/2159
* https://github.com/DynamoRIO/dynamorio/issues/4370

This isn't actually broken on older CMake versions, but I'd rather just disable it outright for the time being. I'll work on an upstream fix.