### PR TITLE
add a yaxpeax worker

### DIFF
--- a/src/worker/Makefile
+++ b/src/worker/Makefile
@@ -6,7 +6,8 @@ WORKERS = bfd \
 	xed \
 	zydis \
 	bddisasm \
-	iced
+	iced \
+	yaxpeax-x86
 
 .PHONY: all
 all: worker $(WORKERS)

--- a/src/worker/yaxpeax-x86/.gitignore
+++ b/src/worker/yaxpeax-x86/.gitignore
@@ -1,0 +1,2 @@
+target/
+libyaxpeax_x86_mishegos.so

--- a/src/worker/yaxpeax-x86/Cargo.toml
+++ b/src/worker/yaxpeax-x86/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "yaxpeax-x86-mishegos"
+version = "0.1.0"
+authors = ["iximeow <git@iximeow.net>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+yaxpeax-x86 = { version = "0.2.0" }
+yaxpeax-arch = "0.0.4"
+
+[build-dependencies]
+bindgen = "*"
+
+[profile.release]
+lto = true
+opt-level = 3

--- a/src/worker/yaxpeax-x86/Makefile
+++ b/src/worker/yaxpeax-x86/Makefile
@@ -1,0 +1,13 @@
+.PHONY: all
+all: libyaxpeax_x86_mishegos.so
+
+libyaxpeax_x86_mishegos.so: target/release/libyaxpeax_x86_mishegos.so
+	cp target/release/libyaxpeax_x86_mishegos.so $@
+
+target/release/libyaxpeax_x86_mishegos.so: src/lib.rs Cargo.toml
+	cargo build --release
+
+.PHONY: clean
+clean:
+	cargo clean
+	rm -f *.so

--- a/src/worker/yaxpeax-x86/build.rs
+++ b/src/worker/yaxpeax-x86/build.rs
@@ -1,0 +1,19 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=wrapper.h");
+
+    let clang_args = env::var("RUST_BINDGEN_CLANG_ARGS").unwrap_or_else(|_| "-I../../include".to_string());
+
+    let bindings = PathBuf::from(env::var("OUT_DIR").unwrap()).join("mishegos.rs");
+    bindgen::Builder::default()
+        .header("../worker.h")
+        .clang_args(clang_args.split_ascii_whitespace())
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .generate()
+        .expect("failed to generate bindings")
+        .write_to_file(bindings)
+        .expect("failed to write bindings");
+}

--- a/src/worker/yaxpeax-x86/src/lib.rs
+++ b/src/worker/yaxpeax-x86/src/lib.rs
@@ -1,0 +1,42 @@
+use std::os::raw::c_char;
+use yaxpeax_x86::long_mode as amd64;
+use yaxpeax_arch::{AddressBase, Decoder, LengthedInstruction};
+
+// shhh no warnings please
+#[allow(warnings)]
+mod mishegos {
+    include!(concat!(env!("OUT_DIR"), "/mishegos.rs"));
+}
+
+use crate::mishegos::{decode_result, MISHEGOS_DEC_MAXLEN, decode_status_S_SUCCESS, decode_status_S_FAILURE, decode_status_S_PARTIAL};
+
+#[no_mangle]
+pub static mut worker_name: *const c_char = b"yaxpeax-x86-mishegos\x00".as_ptr() as *const i8;
+
+#[no_mangle]
+pub extern "C" fn try_decode(decode_result: *mut decode_result, bytes: *const u8, length: u8) {
+    let decode_result = unsafe { decode_result.as_mut().expect("decode_result is not null") };
+    let data = unsafe {
+        std::slice::from_raw_parts(bytes.as_ref().expect("bytes is not null"), length as usize)
+    };
+    let decoder = amd64::InstDecoder::default();
+
+    match decoder.decode(data.iter().cloned()) {
+        Err(amd64::DecodeError::ExhaustedInput) => {
+            decode_result.status = decode_status_S_PARTIAL;
+        }
+        Err(_error) => {
+            decode_result.status = decode_status_S_FAILURE;
+        }
+        Ok(instr) => {
+            decode_result.ndecoded = 0u64.wrapping_offset(instr.len()) as u16;
+            let text = instr.to_string();
+            assert!(text.len() < MISHEGOS_DEC_MAXLEN as usize);
+            for (i, x) in text.as_bytes().iter().enumerate() {
+                decode_result.result[i] = *x as i8;
+            }
+            decode_result.len = text.len() as u16;
+            decode_result.status = decode_status_S_SUCCESS;
+        }
+    };
+}

--- a/workers.spec
+++ b/workers.spec
@@ -7,3 +7,4 @@
 ./src/worker/zydis/zydis.so
 ./src/worker/bddisasm/bddisasm.so
 ./src/worker/iced/iced.so
+./src/worker/yaxpeax-x86/libyaxpeax_x86_mishegos.so


### PR DESCRIPTION
this is heavily inspired by the iced worker, and in fact i suspect the bindgen incantation (to make a rust-friendly binding out of `worker.h`) could probably be factored out. as it stands right now there's nothing too bad about both workers using bindgen, just maybe an extra 10 seconds in total, in a clean build.

incidentally, thank you for mishegos! this made it _substantially_ easier to catch a few small omissions in yaxpeax' sse4 support, and made a large disagreement on how i handle undefined encodings of `{66,f2,f3}0f{,38,3a}` very obvious.

this tracks the `yaxpeax-x86` crate rather than a submodule, mostly because that's a slightly clearer version bump than commit to commit for submodules. i could pull in the crate as a submodule here if you're so inclined.