### PR TITLE
update yaxpeax worker to use 1.0

### DIFF
--- a/src/worker/yaxpeax-x86/Cargo.toml
+++ b/src/worker/yaxpeax-x86/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-yaxpeax-x86 = { version = "0.2.0" }
-yaxpeax-arch = "0.0.5"
+yaxpeax-x86 = { version = "1.0.0" }
+yaxpeax-arch = { version = "0.2.0" }
 
 [build-dependencies]
 bindgen = "*"

--- a/src/worker/yaxpeax-x86/src/lib.rs
+++ b/src/worker/yaxpeax-x86/src/lib.rs
@@ -13,22 +13,30 @@ use crate::mishegos::{decode_result, MISHEGOS_DEC_MAXLEN, decode_status_S_SUCCES
 #[no_mangle]
 pub static mut worker_name: *const c_char = b"yaxpeax-x86-mishegos\x00".as_ptr() as *const i8;
 
+static mut INSTR: Option<amd64::Instruction> = None;
 #[no_mangle]
 pub extern "C" fn try_decode(decode_result: *mut decode_result, bytes: *const u8, length: u8) {
+    unsafe {
+        if INSTR.is_none() {
+            INSTR = Some(amd64::Instruction::default());
+        }
+    }
     let decode_result = unsafe { decode_result.as_mut().expect("decode_result is not null") };
     let data = unsafe {
         std::slice::from_raw_parts(bytes.as_ref().expect("bytes is not null"), length as usize)
     };
     let decoder = amd64::InstDecoder::default();
+    let mut reader = yaxpeax_arch::U8Reader::new(data);
 
-    match decoder.decode(data.iter().cloned()) {
+    match decoder.decode_into(unsafe { INSTR.as_mut().unwrap() }, &mut reader) {
         Err(amd64::DecodeError::ExhaustedInput) => {
             decode_result.status = decode_status_S_PARTIAL;
         }
         Err(_error) => {
             decode_result.status = decode_status_S_FAILURE;
         }
-        Ok(instr) => {
+        Ok(()) => {
+            let instr = unsafe { INSTR.as_ref().unwrap() };
             decode_result.ndecoded = 0u64.wrapping_offset(instr.len()) as u16;
             let text = instr.to_string();
             assert!(text.len() < MISHEGOS_DEC_MAXLEN as usize);


### PR DESCRIPTION
hello! i've released [yaxpeax-x86 1.0](https://crates.io/crates/yaxpeax-x86/1.0.0) and updated the mishegos worker for some slightly adjusted interfaces. i also have the yaxpeax worker decoding into a static mut to increase the odds of mishegos finding a bug from reusing an old `Instruction` struct. there is no change external to the worker _except_ it **makes the worker thread-unsafe**. it looks like the workers are run single-threaded anyway, so i think that's fine?

mishegos pointed me at [about two dozen errors](https://github.com/iximeow/yaxpeax-x86/blob/no-gods-no-/test/long_mode/mod.rs#L3175-L3193) so thank you again for this tool!