### PR TITLE
Add ghidra sleigh support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,18 @@
 [submodule "src/worker/capstone/capstone"]
 	path = src/worker/capstone/capstone
-	url = git://github.com/aquynh/capstone.git
+	url = https://github.com/aquynh/capstone.git
 [submodule "src/worker/xed/xed"]
 	path = src/worker/xed/xed
-	url = git://github.com/intelxed/xed.git
+	url = https://github.com/intelxed/xed.git
 [submodule "src/worker/xed/mbuild"]
 	path = src/worker/xed/mbuild
-	url = git://github.com/intelxed/mbuild.git
+	url = https://github.com/intelxed/mbuild.git
 [submodule "src/worker/zydis/zydis"]
 	path = src/worker/zydis/zydis
-	url = git://github.com/zyantific/zydis.git
+	url = https://github.com/zyantific/zydis.git
 [submodule "src/worker/udis86/udis86"]
 	path = src/worker/udis86/udis86
-	url = git://github.com/vmt/udis86.git
+	url = https://github.com/vmt/udis86.git
 [submodule "src/worker/dynamorio/dynamorio"]
 	path = src/worker/dynamorio/dynamorio
 	url = https://github.com/DynamoRIO/dynamorio.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,9 @@
 [submodule "src/worker/iced/iced"]
 	path = src/worker/iced/iced
 	url = https://github.com/0xd4d/iced.git
+[submodule "src/worker/ghidra/ghidra"]
+	path = src/worker/ghidra/ghidra
+	url = https://github.com/NationalSecurityAgency/ghidra.git
+[submodule "src/worker/ghidra/sleigh-cmake"]
+	path = src/worker/ghidra/sleigh-cmake
+	url = https://github.com/lifting-bits/sleigh.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
-RUN apt-get update
-RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y \
+RUN export DEBIAN_FRONTEND="noninteractive" && \
+    apt-get update && \
+    apt-get install -y \
+        gpg wget && \
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
+    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
+    apt-get update && \
+    apt-get install -y \
         build-essential \
         binutils-dev \
         python \

--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,20 @@ ALL_SRCS := $(shell \
 		-path '*/xed/mbuild/*' -o \
 		-path '*/zydis/zydis/*' -o \
 		-path '*/bddisasm/bddisasm/*' -o \
+		-path '*/ghidra/sleighMishegos*' -o \
 		-path '*/ghidra/ghidra/*' -o \
 		-path '*/ghidra/build/*' -o \
 		-path '*/ghidra/sleigh-cmake/*' \
 	\) \
 	-prune \
-	-o \( -name '*.c' -o -name '*.cc' -o -name '*.h' -o -name '*.hh' \) -print \
+	-o \( \
+		-name 'sleighMishegos*' -o \
+		-name '*.c' -o \
+		-name '*.cc' -o \
+		-name '*.h' -o \
+		-name '*.hh' \
+	\) \
+	-print \
 )
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,13 @@ ALL_SRCS := $(shell \
 		-path '*/xed/xed/*' -o \
 		-path '*/xed/mbuild/*' -o \
 		-path '*/zydis/zydis/*' -o \
-		-path '*/bddisasm/bddisasm/*' \
+		-path '*/bddisasm/bddisasm/*' -o \
+		-path '*/ghidra/ghidra/*' -o \
+		-path '*/ghidra/build/*' -o \
+		-path '*/ghidra/sleigh-cmake/*' \
 	\) \
 	-prune \
-	-o \( -name '*.c' -o -name '*.h' \) -print \
+	-o \( -name '*.c' -o -name '*.cc' -o -name '*.h' \) -print \
 )
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ALL_SRCS := $(shell \
 		-path '*/ghidra/sleigh-cmake/*' \
 	\) \
 	-prune \
-	-o \( -name '*.c' -o -name '*.cc' -o -name '*.h' \) -print \
+	-o \( -name '*.c' -o -name '*.cc' -o -name '*.h' -o -name '*.hh' \) -print \
 )
 
 .PHONY: all

--- a/src/analysis/pass/filter-destroy-ghidra/filter-destroy-ghidra
+++ b/src/analysis/pass/filter-destroy-ghidra/filter-destroy-ghidra
@@ -5,9 +5,9 @@
 
 require "json"
 
-# TODO(ww): Remove this.
 XED_SO = "./src/worker/xed/xed.so"
 ZYDIS_SO = "./src/worker/zydis/zydis.so"
+ICED_SO = "./src/worker/iced/iced.so"
 GHIDRA_SO = "./src/worker/ghidra/ghidra.so"
 
 warn "[+] pass: filter-destroy-ghidra"
@@ -18,9 +18,12 @@ $stdin.each_line do |line|
 
   xed = result[:outputs].find { |o| o[:worker_so] == XED_SO }
   zydis = result[:outputs].find { |o| o[:worker_so] == ZYDIS_SO }
+  iced = result[:outputs].find { |o| o[:worker_so] == ICED_SO }
   ghidra = result[:outputs].find { |o| o[:worker_so] == GHIDRA_SO }
 
-  if ghidra[:status][:value] == xed[:status][:value] && ghidra[:status][:value] == zydis[:status][:value]
+  if ghidra[:status][:value] == xed[:status][:value] &&
+      ghidra[:status][:value] == zydis[:status][:value] &&
+      ghidra[:status][:value] == iced[:status][:value]
     count += 1
     next
   end

--- a/src/analysis/pass/filter-destroy-ghidra/filter-destroy-ghidra
+++ b/src/analysis/pass/filter-destroy-ghidra/filter-destroy-ghidra
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# filter-destroy-ghidra: find results that only ghidra gets right (or wrong)
+
+require "json"
+
+# TODO(ww): Remove this.
+XED_SO = "./src/worker/xed/xed.so"
+ZYDIS_SO = "./src/worker/zydis/zydis.so"
+GHIDRA_SO = "./src/worker/ghidra/ghidra.so"
+
+warn "[+] pass: filter-destroy-ghidra"
+
+count = 0
+$stdin.each_line do |line|
+  result = JSON.parse line, symbolize_names: true
+
+  xed = result[:outputs].find { |o| o[:worker_so] == XED_SO }
+  zydis = result[:outputs].find { |o| o[:worker_so] == ZYDIS_SO }
+  ghidra = result[:outputs].find { |o| o[:worker_so] == GHIDRA_SO }
+
+  if ghidra[:status][:value] == xed[:status][:value] && ghidra[:status][:value] == zydis[:status][:value]
+    count += 1
+    next
+  end
+
+  $stdout.puts result.to_json
+end
+
+warn "[+] pass: filter-destroy-ghidra done: #{count} filtered"

--- a/src/analysis/pass/filter-destroy-ghidra/spec.yml
+++ b/src/analysis/pass/filter-destroy-ghidra/spec.yml
@@ -1,0 +1,3 @@
+name: filter-destroy-ghidra
+desc: Find results that only ghidra gets right (or wrong)
+run: filter-destroy-ghidra

--- a/src/analysis/pass/filter-ghidra-lock/filter-ghidra-lock
+++ b/src/analysis/pass/filter-ghidra-lock/filter-ghidra-lock
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# filter-ghidra-lock: Find Ghidra results that decode to "LOCK"
+# instruction. "LOCK" is a prefix, not a real instruction:
+# https://github.com/NationalSecurityAgency/ghidra/issues/2033#issue-645334803
+
+require "json"
+
+GHIDRA_SO = "./src/worker/ghidra/ghidra.so"
+
+warn "[+] pass: filter-ghidra-lock"
+
+count = 0
+$stdin.each_line do |line|
+  result = JSON.parse line, symbolize_names: true
+
+  ghidra = result[:outputs].find { |o| o[:worker_so] == GHIDRA_SO }
+
+  if ghidra[:result] == "LOCK"
+    count += 1
+    next
+  end
+
+  $stdout.puts result.to_json
+end
+
+warn "[+] pass: filter-ghidra-lock done: #{count} filtered"

--- a/src/analysis/pass/filter-ghidra-lock/spec.yml
+++ b/src/analysis/pass/filter-ghidra-lock/spec.yml
@@ -1,0 +1,3 @@
+name: filter-ghidra-lock
+desc: Find ghidra results that decode to LOCK
+run: filter-ghidra-lock

--- a/src/analysis/passes.yml
+++ b/src/analysis/passes.yml
@@ -52,6 +52,14 @@ destroy-bddisasm:
   - minimize-input
   - normalize
 
+destroy-ghidra:
+  - filter-all-success
+  - filter-ndecoded-same
+  - dedupe
+  - filter-destroy-ghidra
+  - minimize-input
+  - normalize
+
 xed-overaccept:
   - filter-all-success
   - filter-ndecoded-same

--- a/src/analysis/passes.yml
+++ b/src/analysis/passes.yml
@@ -56,6 +56,7 @@ destroy-ghidra:
   - filter-all-success
   - filter-ndecoded-same
   - dedupe
+  - filter-ghidra-lock
   - filter-destroy-ghidra
   - minimize-input
   - normalize

--- a/src/mishmat/mishmat
+++ b/src/mishmat/mishmat
@@ -27,6 +27,10 @@ HEADER = ERB.new <<~HTML
           border: 1px solid black;
         }
 
+        table tr:hover > td {
+          border: 5px solid black;
+        }
+
         th, td {
           text-align: left;
         }

--- a/src/worker/Makefile
+++ b/src/worker/Makefile
@@ -7,7 +7,8 @@ WORKERS = bfd \
 	zydis \
 	bddisasm \
 	iced \
-	yaxpeax-x86
+	yaxpeax-x86 \
+	ghidra
 
 .PHONY: all
 all: worker $(WORKERS)

--- a/src/worker/ghidra/.gitignore
+++ b/src/worker/ghidra/.gitignore
@@ -1,0 +1,2 @@
+/build
+/ghidra.so

--- a/src/worker/ghidra/CMakeLists.txt
+++ b/src/worker/ghidra/CMakeLists.txt
@@ -20,7 +20,7 @@ get_filename_component(mishegos_include_dir "../../include"
   ABSOLUTE BASE_DIR ${PROJECT_SOURCE_DIRECTORY}
 )
 target_include_directories(mishegos_ghidra
-  PRIVATE $<BUILD_INTERFACE:${mishegos_include_dir}>
+  PRIVATE "$<BUILD_INTERFACE:${mishegos_include_dir}>"
 )
 
 add_dependencies(mishegos_ghidra

--- a/src/worker/ghidra/CMakeLists.txt
+++ b/src/worker/ghidra/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(mishegos_ghidra)
+
+# Pull in the CMake sleigh build support
+add_subdirectory(sleigh-cmake EXCLUDE_FROM_ALL)
+
+add_library(mishegos_ghidra SHARED ghidra.cc sleighMishegos.cc)
+set_target_properties(mishegos_ghidra
+  PROPERTIES
+    OUTPUT_NAME ghidra
+    PREFIX ""
+)
+
+target_link_libraries(mishegos_ghidra PRIVATE sleigh::sla)
+
+# TODO: Not sure how to get this into the project for only linking against the
+# mishegos shared library
+get_filename_component(mishegos_include_dir "../../include"
+  ABSOLUTE BASE_DIR ${PROJECT_SOURCE_DIRECTORY}
+)
+target_include_directories(mishegos_ghidra
+  PRIVATE $<BUILD_INTERFACE:${mishegos_include_dir}>
+)
+
+add_dependencies(mishegos_ghidra
+  sleigh_spec_x86-64
+)

--- a/src/worker/ghidra/CMakeLists.txt
+++ b/src/worker/ghidra/CMakeLists.txt
@@ -11,6 +11,7 @@ set_target_properties(mishegos_ghidra
     OUTPUT_NAME ghidra
     PREFIX ""
 )
+target_compile_features(mishegos_ghidra PUBLIC cxx_std_11)
 
 target_link_libraries(mishegos_ghidra PRIVATE sleigh::sla)
 

--- a/src/worker/ghidra/Makefile
+++ b/src/worker/ghidra/Makefile
@@ -10,11 +10,12 @@ ghidra.so:
 	cmake -B build -S . \
 		-DCMAKE_BUILD_TYPE=Release \
 		-Dsleigh_GHIDRA_RELEASE_TYPE=HEAD \
-		-DFETCHCONTENT_SOURCE_DIR_GHIDRASOURCE="./ghidra"
+		"-DFETCHCONTENT_SOURCE_DIR_GHIDRASOURCE=./ghidra"
 	cmake --build build -j --verbose
 	cp build/ghidra.so ./ghidra.so
 
-# Uncomment to build with address sanitizer
+# Uncomment to build with address sanitizer. Remember to remove 'build'
+# directory if switching between the two
 #.PHONY: ghidra.so
 #.ONESHELL:
 #ghidra.so:
@@ -24,7 +25,7 @@ ghidra.so:
 #		"-DCMAKE_C_FLAGS=-Wall -Wpedantic -Wextra -fsanitize=address" \
 #		"-DCMAKE_CXX_FLAGS=-Wall -Wpedantic -Wextra -Wconversion -Wsign-conversion -Wcast-qual -Wshadow -Wformat=2 -Wundef -fsanitize=address" \
 #		"-DCMAKE_MODULE_LINKER_FLAGS=-fsanitize=address" \
-#		-DFETCHCONTENT_SOURCE_DIR_GHIDRASOURCE="./ghidra"
+#		"-DFETCHCONTENT_SOURCE_DIR_GHIDRASOURCE=./ghidra"
 #	cmake --build build -j --verbose
 #	cp build/ghidra.so ./ghidra.so
 

--- a/src/worker/ghidra/Makefile
+++ b/src/worker/ghidra/Makefile
@@ -14,6 +14,20 @@ ghidra.so:
 	cmake --build build -j --verbose
 	cp build/ghidra.so ./ghidra.so
 
+# Uncomment to build with address sanitizer
+#.PHONY: ghidra.so
+#.ONESHELL:
+#ghidra.so:
+#	cmake -B build -S . \
+#		-DCMAKE_BUILD_TYPE=Debug \
+#		-Dsleigh_GHIDRA_RELEASE_TYPE=HEAD \
+#		"-DCMAKE_C_FLAGS=-Wall -Wpedantic -Wextra -fsanitize=address" \
+#		"-DCMAKE_CXX_FLAGS=-Wall -Wpedantic -Wextra -Wconversion -Wsign-conversion -Wcast-qual -Wshadow -Wformat=2 -Wundef -fsanitize=address" \
+#		"-DCMAKE_MODULE_LINKER_FLAGS=-fsanitize=address" \
+#		-DFETCHCONTENT_SOURCE_DIR_GHIDRASOURCE="./ghidra"
+#	cmake --build build -j --verbose
+#	cp build/ghidra.so ./ghidra.so
+
 .PHONY: clean
 clean:
 	rm -rf build

--- a/src/worker/ghidra/Makefile
+++ b/src/worker/ghidra/Makefile
@@ -9,7 +9,7 @@ all: ghidra.so
 ghidra.so:
 	cmake -B build -S . \
 		-DCMAKE_BUILD_TYPE=Release \
-		-Dsleigh_GHIDRA_RELEASE_TYPE=stable \
+		-Dsleigh_GHIDRA_RELEASE_TYPE=HEAD \
 		-DFETCHCONTENT_SOURCE_DIR_GHIDRASOURCE="./ghidra"
 	cmake --build build -j --verbose
 	cp build/ghidra.so ./ghidra.so

--- a/src/worker/ghidra/Makefile
+++ b/src/worker/ghidra/Makefile
@@ -14,4 +14,4 @@ ghidra.so:
 .PHONY: clean
 clean:
 	rm -rf build
-	rm ./ghidra.so
+	rm -f ./ghidra.so

--- a/src/worker/ghidra/Makefile
+++ b/src/worker/ghidra/Makefile
@@ -7,7 +7,10 @@ all: ghidra.so
 .PHONY: ghidra.so
 .ONESHELL:
 ghidra.so:
-	cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DSLEIGH_GHIDRA_RELEASE_TYPE=HEAD -DFETCHCONTENT_SOURCE_DIR_GHIDRASOURCE="./ghidra"
+	cmake -B build -S . \
+		-DCMAKE_BUILD_TYPE=Release \
+		-Dsleigh_GHIDRA_RELEASE_TYPE=stable \
+		-DFETCHCONTENT_SOURCE_DIR_GHIDRASOURCE="./ghidra"
 	cmake --build build -j --verbose
 	cp build/ghidra.so ./ghidra.so
 

--- a/src/worker/ghidra/Makefile
+++ b/src/worker/ghidra/Makefile
@@ -1,0 +1,17 @@
+override LDFLAGS :=
+override CXXFLAGS :=
+
+.PHONY: all
+all: ghidra.so
+
+.PHONY: ghidra.so
+.ONESHELL:
+ghidra.so:
+	cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DSLEIGH_GHIDRA_RELEASE_TYPE=HEAD -DFETCHCONTENT_SOURCE_DIR_GHIDRASOURCE="./ghidra"
+	cmake --build build -j --verbose
+	cp build/ghidra.so ./ghidra.so
+
+.PHONY: clean
+clean:
+	rm -rf build
+	rm ./ghidra.so

--- a/src/worker/ghidra/ghidra.cc
+++ b/src/worker/ghidra/ghidra.cc
@@ -1,0 +1,141 @@
+#include <sleigh/loadimage.hh>
+
+#include <iostream>
+#include <exception>
+#include <typeinfo>
+#include <stdexcept>
+
+#include "sleighMishegos.hh"
+#include "../worker.h"
+#include "mish_common.h"
+
+extern "C" {
+char *worker_name = (char *)"ghidra";
+
+void worker_ctor();
+
+void try_decode(decode_result *result, uint8_t *raw_insn, uint8_t length);
+}
+
+// This is a tiny LoadImage class which feeds the executable bytes to the translator
+class MyLoadImage : public LoadImage {
+  uintb baseaddr;
+  int4 length;
+  uint1 *data;
+
+public:
+  MyLoadImage(uintb ad, uint1 *ptr, int4 sz) : LoadImage("nofile") {
+    baseaddr = ad;
+    data = ptr;
+    length = sz;
+  }
+  virtual void loadFill(uint1 *ptr, int4 size, const Address &addr);
+  virtual string getArchType(void) const {
+    return "x86:LE:64:default";
+  }
+  virtual void adjustVma(long adjust) {
+  }
+  virtual void setData(uint1 *ptr, int4 sz) {
+    this->data = ptr;
+    this->length = sz;
+  }
+};
+
+// This is the only important method for the LoadImage. It returns bytes from the static array
+// depending on the address range requested
+void MyLoadImage::loadFill(uint1 *ptr, int4 size, const Address &addr) {
+  uintb start = addr.getOffset();
+  uintb max = baseaddr + (length - 1);
+  for (int4 i = 0; i < size; ++i) {              // For every byte requestes
+    uintb curoff = start + i;                    // Calculate offset of byte
+    if ((curoff < baseaddr) || (curoff > max)) { // If byte does not fall in window
+      ptr[i] = 0;                                // return 0
+      continue;
+    }
+    uintb diff = curoff - baseaddr;
+    ptr[i] = data[(int4)diff]; // Otherwise return data from our window
+  }
+}
+
+// Here is a simple class for emitting assembly.  In this case, we send the strings straight
+// to the result.
+class AssemblyMishegos : public AssemblyEmit {
+  decode_result *result;
+
+public:
+  AssemblyMishegos(decode_result *dr) : result(dr){};
+  virtual void dump(const Address &addr, const string &mnem, const string &body) {
+    // std::cout << ": " << mnem << ' ' << body << std::endl;
+    result->status = S_SUCCESS;
+    result->len =
+        snprintf(result->result, MISHEGOS_DEC_MAXLEN, "%s %s\n", mnem.c_str(), body.c_str());
+  }
+};
+
+static const uintb START_ADDRESS = 0x0;
+
+// Storing data files
+static DocumentStorage docstorage;
+
+// Context for disassembly
+static ContextInternal context;
+
+// Loader for reading instruction bytes
+static MyLoadImage loader(START_ADDRESS, nullptr, 0);
+
+// Translator for doing disassembly
+static SleighMishegos trans(&loader, &context);
+
+void worker_ctor() {
+  // Set up the assembler/pcode-translator
+  string sleighfilename = "src/worker/ghidra/build/sleigh-cmake/specfiles/Ghidra/Processors/x86/"
+                          "data/languages/x86-64.sla";
+  // Need this for correctly setting up the 64 bit x86 mode
+  string pspecfilename = "src/worker/ghidra/build/sleigh-cmake/specfiles/Ghidra/Processors/x86/"
+                         "data/languages/x86-64.pspec";
+
+  // Read sleigh and spec file into DOM
+  Element *sleighroot = docstorage.openDocument(sleighfilename)->getRoot();
+  docstorage.registerTag(sleighroot);
+  Element *specroot = docstorage.openDocument(pspecfilename)->getRoot();
+  docstorage.registerTag(specroot);
+
+  trans.initialize(docstorage); // Initialize the translator
+  // Single instruction disasm. Prevent instructions from messing up future
+  // instruction disassembly
+  trans.allowContextSet(false);
+
+  // Now that context symbol names are loaded by the translator
+  // we can set the default context
+  // This imitates what is done in
+  //   void Architecture::parseProcessorConfig(DocumentStorage &store)
+  const Element *el = docstorage.getTag("processor_spec");
+  const List &list(el->getChildren());
+  for (List::const_iterator iter = list.begin(); iter != list.end(); ++iter) {
+    const string &elname((*iter)->getName());
+    if (elname == "context_data") {
+      context.restoreFromSpec(*iter, &trans);
+      break;
+    }
+  }
+}
+
+void try_decode(decode_result *result, uint8_t *raw_insn, uint8_t length) {
+  loader.setData(raw_insn, length);
+
+  // Set up the disassembly dumper
+  AssemblyMishegos assememit(result);
+
+  // Starting disassembly address
+  Address addr(trans.getDefaultCodeSpace(), START_ADDRESS);
+
+  try {
+    result->ndecoded = trans.printAssembly(assememit, addr);
+  } catch (...) {
+    // Uncomment for debugging exception info
+    // std::exception_ptr p = std::current_exception();
+    // std::cout << (p ? p.__cxa_exception_type()->name() : "null") << std::endl;
+
+    result->status = S_FAILURE;
+  }
+}

--- a/src/worker/ghidra/ghidra.cc
+++ b/src/worker/ghidra/ghidra.cc
@@ -15,7 +15,7 @@
 #include "mish_common.h"
 
 extern "C" {
-char *worker_name = (char *)"ghidra";
+const char *worker_name = (const char *)"ghidra";
 
 void worker_ctor();
 
@@ -31,10 +31,8 @@ class MyLoadImage : public LoadImage {
 public:
   // "nofile" doesn't have any special meaning. Just doing what was done in
   // sleighExample.cc
-  MyLoadImage(uintb ad, uint1 *ptr, int4 sz) : LoadImage("nofile") {
-    baseaddr = ad;
-    data = ptr;
-    length = sz;
+  MyLoadImage(uintb ad, uint1 *ptr, int4 sz)
+      : LoadImage("nofile"), baseaddr{ad}, length{sz}, data{ptr} {
   }
   virtual void loadFill(uint1 *ptr, int4 size, const Address &addr) override;
   string getArchType(void) const override {

--- a/src/worker/ghidra/ghidra.cc
+++ b/src/worker/ghidra/ghidra.cc
@@ -1,3 +1,8 @@
+/**
+ * This file is based loosely on Ghidra's sleighexample.cc file for
+ * initializing and loading bytes for sleigh to disassemble
+ *   https://github.com/NationalSecurityAgency/ghidra/blob/47f76c78d6b7d5c56a9256b0666620863805ff30/Ghidra/Features/Decompiler/src/decompile/cpp/sleighexample.cc
+ */
 #include <sleigh/loadimage.hh>
 
 #include <iostream>
@@ -24,6 +29,8 @@ class MyLoadImage : public LoadImage {
   uint1 *data;
 
 public:
+  // "nofile" doesn't have any special meaning. Just doing what was done in
+  // sleighExample.cc
   MyLoadImage(uintb ad, uint1 *ptr, int4 sz) : LoadImage("nofile") {
     baseaddr = ad;
     data = ptr;

--- a/src/worker/ghidra/ghidra.cc
+++ b/src/worker/ghidra/ghidra.cc
@@ -30,7 +30,7 @@ public:
     length = sz;
   }
   virtual void loadFill(uint1 *ptr, int4 size, const Address &addr);
-  virtual string getArchType(void) const {
+  string getArchType(void) const override {
     return "x86:LE:64:default";
   }
   virtual void adjustVma(long adjust) {
@@ -65,7 +65,6 @@ class AssemblyMishegos : public AssemblyEmit {
 public:
   AssemblyMishegos(decode_result *dr) : result(dr){};
   virtual void dump(const Address &addr, const string &mnem, const string &body) {
-    // std::cout << ": " << mnem << ' ' << body << std::endl;
     result->status = S_SUCCESS;
     result->len =
         snprintf(result->result, MISHEGOS_DEC_MAXLEN, "%s %s\n", mnem.c_str(), body.c_str());
@@ -111,10 +110,10 @@ void worker_ctor() {
   //   void Architecture::parseProcessorConfig(DocumentStorage &store)
   const Element *el = docstorage.getTag("processor_spec");
   const List &list(el->getChildren());
-  for (List::const_iterator iter = list.begin(); iter != list.end(); ++iter) {
-    const string &elname((*iter)->getName());
+  for (const auto &l : list) {
+    const string &elname(l->getName());
     if (elname == "context_data") {
-      context.restoreFromSpec(*iter, &trans);
+      context.restoreFromSpec(l, &trans);
       break;
     }
   }

--- a/src/worker/ghidra/sleighMishegos.cc
+++ b/src/worker/ghidra/sleighMishegos.cc
@@ -1,0 +1,261 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This class was copied from upstream
+ * https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh.cc
+ *
+ * Modified by Eric Kilmer at Trail of Bits 2021
+ * Modified to better support mishegos single-shot disassembly by removing the
+ * caching of disassembly results at the same address without having to
+ * reinitialize the class.
+ */
+#include "sleighMishegos.hh"
+
+#include <sleigh/sleighbase.hh>
+#include <sleigh/loadimage.hh>
+
+/// \param ld is the LoadImage to draw program bytes from
+/// \param c_db is the context database
+SleighMishegos::SleighMishegos(LoadImage *ld, ContextDatabase *c_db)
+    : SleighBase()
+
+{
+  loader = ld;
+  context_db = c_db;
+  cache = new ContextCache(c_db);
+  pos = new ParserContext(cache);
+
+  // Values taken from DisassemblyCache::initialize
+  pos->initialize(75, 20, getConstantSpace());
+}
+
+void SleighMishegos::clearForDelete(void)
+
+{
+  delete cache;
+  delete pos;
+}
+
+SleighMishegos::~SleighMishegos(void)
+
+{
+  clearForDelete();
+}
+
+/// Completely clear everything except the base and reconstruct
+/// with a new LoadImage and ContextDatabase
+/// \param ld is the new LoadImage
+/// \param c_db is the new ContextDatabase
+void SleighMishegos::reset(LoadImage *ld, ContextDatabase *c_db)
+
+{
+  clearForDelete();
+  loader = ld;
+  context_db = c_db;
+  cache = new ContextCache(c_db);
+}
+
+/// The .sla file from the document store is loaded and cache objects are prepared
+/// \param store is the document store containing the main \<sleigh> tag.
+void SleighMishegos::initialize(DocumentStorage &store)
+
+{
+  if (!isInitialized()) { // Initialize the base if not already
+    const Element *el = store.getTag("sleigh");
+    if (el == (const Element *)0)
+      throw LowlevelError("Could not find sleigh tag");
+    restoreXml(el);
+  } else
+    reregisterContext();
+}
+
+/// \brief Obtain a parse tree for the instruction at the given address
+///
+/// The tree may be cached from a previous access.  If the address
+/// has not been parsed, disassembly is performed, and a new parse tree
+/// is prepared.  Depending on the desired \e state, the parse tree
+/// can be prepared either for disassembly or for p-code generation.
+/// \param addr is the given address of the instruction
+/// \param state is the desired parse state.
+/// \return the parse tree object (ParseContext)
+ParserContext *SleighMishegos::obtainContext(const Address &addr, int4 state) const
+
+{
+  pos->setAddr(addr);
+  pos->setParserState(ParserContext::uninitialized);
+
+  resolve(*pos);
+  if (state == ParserContext::disassembly)
+    return pos;
+
+  // If we reach here,  state must be ParserContext::pcode
+  resolveHandles(*pos);
+  return pos;
+}
+
+/// Resolve \e all the constructors involved in the instruction at the indicated address
+/// \param pos is the parse object that will hold the resulting tree
+void SleighMishegos::resolve(ParserContext &pos) const
+
+{
+  loader->loadFill(pos.getBuffer(), 16, pos.getAddr());
+  ParserWalkerChange walker(&pos);
+  pos.deallocateState(walker); // Clear the previous resolve and initialize the walker
+  Constructor *ct, *subct;
+  uint4 off;
+  int4 oper, numoper;
+
+  pos.setDelaySlot(0);
+  walker.setOffset(0);        // Initial offset
+  pos.clearCommits();         // Clear any old context commits
+  pos.loadContext();          // Get context for current address
+  ct = root->resolve(walker); // Base constructor
+  walker.setConstructor(ct);
+  ct->applyContext(walker);
+  while (walker.isState()) {
+    ct = walker.getConstructor();
+    oper = walker.getOperand();
+    numoper = ct->getNumOperands();
+    while (oper < numoper) {
+      OperandSymbol *sym = ct->getOperand(oper);
+      off = walker.getOffset(sym->getOffsetBase()) + sym->getRelativeOffset();
+      pos.allocateOperand(oper, walker); // Descend into new operand and reserve space
+      walker.setOffset(off);
+      TripleSymbol *tsym = sym->getDefiningSymbol();
+      if (tsym != (TripleSymbol *)0) {
+        subct = tsym->resolve(walker);
+        if (subct != (Constructor *)0) {
+          walker.setConstructor(subct);
+          subct->applyContext(walker);
+          break;
+        }
+      }
+      walker.setCurrentLength(sym->getMinimumLength());
+      walker.popOperand();
+      oper += 1;
+    }
+    if (oper >= numoper) { // Finished processing constructor
+      walker.calcCurrentLength(ct->getMinimumLength(), numoper);
+      walker.popOperand();
+      // Check for use of delayslot
+      ConstructTpl *templ = ct->getTempl();
+      if ((templ != (ConstructTpl *)0) && (templ->delaySlot() > 0))
+        pos.setDelaySlot(templ->delaySlot());
+    }
+  }
+  pos.setNaddr(pos.getAddr() + pos.getLength()); // Update Naddr to pointer after instruction
+  pos.setParserState(ParserContext::disassembly);
+}
+
+/// Resolve handle templates for the given parse tree, assuming Constructors
+/// are already resolved.
+/// \param pos is the given parse tree
+void SleighMishegos::resolveHandles(ParserContext &pos) const
+
+{
+  TripleSymbol *triple;
+  Constructor *ct;
+  int4 oper, numoper;
+
+  ParserWalker walker(&pos);
+  walker.baseState();
+  while (walker.isState()) {
+    ct = walker.getConstructor();
+    oper = walker.getOperand();
+    numoper = ct->getNumOperands();
+    while (oper < numoper) {
+      OperandSymbol *sym = ct->getOperand(oper);
+      walker.pushOperand(oper); // Descend into node
+      triple = sym->getDefiningSymbol();
+      if (triple != (TripleSymbol *)0) {
+        if (triple->getType() == SleighSymbol::subtable_symbol)
+          break;
+        else // Some other kind of symbol as an operand
+          triple->getFixedHandle(walker.getParentHandle(), walker);
+      } else { // Must be an expression
+        PatternExpression *patexp = sym->getDefiningExpression();
+        intb res = patexp->getValue(walker);
+        FixedHandle &hand(walker.getParentHandle());
+        hand.space = pos.getConstSpace(); // Result of expression is a constant
+        hand.offset_space = (AddrSpace *)0;
+        hand.offset_offset = (uintb)res;
+        hand.size = 0; // This size should not get used
+      }
+      walker.popOperand();
+      oper += 1;
+    }
+    if (oper >= numoper) { // Finished processing constructor
+      ConstructTpl *templ = ct->getTempl();
+      if (templ != (ConstructTpl *)0) {
+        HandleTpl *res = templ->getResult();
+        if (res != (HandleTpl *)0) // Pop up handle to containing operand
+          res->fix(walker.getParentHandle(), walker);
+        // If we need an indicator that the constructor exports nothing try
+        // else
+        //   walker.getParentHandle().setInvalid();
+      }
+      walker.popOperand();
+    }
+  }
+  pos.setParserState(ParserContext::pcode);
+}
+
+int4 SleighMishegos::instructionLength(const Address &baseaddr) const
+
+{
+  ParserContext *pos = obtainContext(baseaddr, ParserContext::disassembly);
+  return pos->getLength();
+}
+
+int4 SleighMishegos::printAssembly(AssemblyEmit &emit, const Address &baseaddr) const
+
+{
+  int4 sz;
+
+  ParserContext *pos = obtainContext(baseaddr, ParserContext::disassembly);
+  ParserWalker walker(pos);
+  walker.baseState();
+
+  Constructor *ct = walker.getConstructor();
+  ostringstream mons;
+  ct->printMnemonic(mons, walker);
+  ostringstream body;
+  ct->printBody(body, walker);
+  emit.dump(baseaddr, mons.str(), body.str());
+  sz = pos->getLength();
+  return sz;
+}
+
+int4 SleighMishegos::oneInstruction(PcodeEmit &emit, const Address &baseaddr) const
+
+{
+  throw UnimplError("Unimplemented oneInstruction", 0);
+}
+
+void SleighMishegos::registerContext(const string &name, int4 sbit, int4 ebit)
+
+{
+  context_db->registerVariable(name, sbit, ebit);
+}
+
+void SleighMishegos::setContextDefault(const string &name, uintm val)
+
+{
+  context_db->setVariableDefault(name, val);
+}
+
+void SleighMishegos::allowContextSet(bool val) const
+
+{
+  cache->allowSet(val);
+}

--- a/src/worker/ghidra/sleighMishegos.cc
+++ b/src/worker/ghidra/sleighMishegos.cc
@@ -26,26 +26,19 @@
 
 /// \param ld is the LoadImage to draw program bytes from
 /// \param c_db is the context database
-SleighMishegos::SleighMishegos(LoadImage *ld, ContextDatabase *c_db)
-    : SleighBase()
-
-{
+SleighMishegos::SleighMishegos(LoadImage *ld, ContextDatabase *c_db) : SleighBase() {
   loader = ld;
   context_db = c_db;
   cache = new ContextCache(c_db);
   pos = nullptr;
 }
 
-void SleighMishegos::clearForDelete(void)
-
-{
+void SleighMishegos::clearForDelete(void) {
   delete cache;
   delete pos;
 }
 
-SleighMishegos::~SleighMishegos(void)
-
-{
+SleighMishegos::~SleighMishegos(void) {
   clearForDelete();
 }
 
@@ -53,9 +46,7 @@ SleighMishegos::~SleighMishegos(void)
 /// with a new LoadImage and ContextDatabase
 /// \param ld is the new LoadImage
 /// \param c_db is the new ContextDatabase
-void SleighMishegos::reset(LoadImage *ld, ContextDatabase *c_db)
-
-{
+void SleighMishegos::reset(LoadImage *ld, ContextDatabase *c_db) {
   clearForDelete();
   loader = ld;
   context_db = c_db;
@@ -64,9 +55,7 @@ void SleighMishegos::reset(LoadImage *ld, ContextDatabase *c_db)
 
 /// The .sla file from the document store is loaded and cache objects are prepared
 /// \param store is the document store containing the main \<sleigh> tag.
-void SleighMishegos::initialize(DocumentStorage &store)
-
-{
+void SleighMishegos::initialize(DocumentStorage &store) {
   if (!isInitialized()) { // Initialize the base if not already
     const Element *el = store.getTag("sleigh");
     if (el == (const Element *)0)
@@ -90,9 +79,7 @@ void SleighMishegos::initialize(DocumentStorage &store)
 /// \param addr is the given address of the instruction
 /// \param state is the desired parse state.
 /// \return the parse tree object (ParseContext)
-ParserContext *SleighMishegos::obtainContext(const Address &addr, int4 state) const
-
-{
+ParserContext *SleighMishegos::obtainContext(const Address &addr, int4 state) const {
   pos->setAddr(addr);
   pos->setParserState(ParserContext::uninitialized);
 
@@ -107,9 +94,7 @@ ParserContext *SleighMishegos::obtainContext(const Address &addr, int4 state) co
 
 /// Resolve \e all the constructors involved in the instruction at the indicated address
 /// \param pc is the parse object that will hold the resulting tree
-void SleighMishegos::resolve(ParserContext &pc) const
-
-{
+void SleighMishegos::resolve(ParserContext &pc) const {
   loader->loadFill(pc.getBuffer(), 16, pc.getAddr());
   ParserWalkerChange walker(&pc);
   pc.deallocateState(walker); // Clear the previous resolve and initialize the walker
@@ -162,9 +147,7 @@ void SleighMishegos::resolve(ParserContext &pc) const
 /// Resolve handle templates for the given parse tree, assuming Constructors
 /// are already resolved.
 /// \param pc is the given parse tree
-void SleighMishegos::resolveHandles(ParserContext &pc) const
-
-{
+void SleighMishegos::resolveHandles(ParserContext &pc) const {
   TripleSymbol *triple;
   Constructor *ct;
   int4 oper, numoper;
@@ -212,16 +195,12 @@ void SleighMishegos::resolveHandles(ParserContext &pc) const
   pc.setParserState(ParserContext::pcode);
 }
 
-int4 SleighMishegos::instructionLength(const Address &baseaddr) const
-
-{
+int4 SleighMishegos::instructionLength(const Address &baseaddr) const {
   ParserContext *pc = obtainContext(baseaddr, ParserContext::disassembly);
   return pc->getLength();
 }
 
-int4 SleighMishegos::printAssembly(AssemblyEmit &emit, const Address &baseaddr) const
-
-{
+int4 SleighMishegos::printAssembly(AssemblyEmit &emit, const Address &baseaddr) const {
   int4 sz;
 
   ParserContext *pc = obtainContext(baseaddr, ParserContext::disassembly);
@@ -238,26 +217,18 @@ int4 SleighMishegos::printAssembly(AssemblyEmit &emit, const Address &baseaddr) 
   return sz;
 }
 
-int4 SleighMishegos::oneInstruction(PcodeEmit &, const Address &) const
-
-{
+int4 SleighMishegos::oneInstruction(PcodeEmit &, const Address &) const {
   throw UnimplError("Unimplemented oneInstruction", 0);
 }
 
-void SleighMishegos::registerContext(const string &name, int4 sbit, int4 ebit)
-
-{
+void SleighMishegos::registerContext(const string &name, int4 sbit, int4 ebit) {
   context_db->registerVariable(name, sbit, ebit);
 }
 
-void SleighMishegos::setContextDefault(const string &name, uintm val)
-
-{
+void SleighMishegos::setContextDefault(const string &name, uintm val) {
   context_db->setVariableDefault(name, val);
 }
 
-void SleighMishegos::allowContextSet(bool val) const
-
-{
+void SleighMishegos::allowContextSet(bool val) const {
   cache->allowSet(val);
 }

--- a/src/worker/ghidra/sleighMishegos.cc
+++ b/src/worker/ghidra/sleighMishegos.cc
@@ -1,44 +1,542 @@
-/**
+/* ###
+ * IP: GHIDRA
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * This class was copied from upstream
- * https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh.cc
+ * This file was copied from upstream
+ * https://github.com/NationalSecurityAgency/ghidra/blob/47f76c78d6b7d5c56a9256b0666620863805ff30/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh.cc
  *
- * Modified by Eric Kilmer at Trail of Bits 2021
- * Modified to better support mishegos single-shot disassembly by removing the
- * caching of disassembly results at the same address without having to
- * reinitialize the class.
+ * Modified by Eric Kilmer at Trail of Bits 2022
+ * Modified to better support mishegos single-shot disassembly by not using the
+ * disassembly cache. This allows us to get new disassembly results at the same
+ * address without having to reinitialize everything.
+ *
+ * This file has been modified in a way to minimize the diff from upstream.
+ * There is dead code and other code artifacts that probably wouldn't be
+ * written in the same way had this functionality been written fresh.
  */
 #include "sleighMishegos.hh"
-
-#include <sleigh/sleighbase.hh>
 #include <sleigh/loadimage.hh>
+
+PcodeCacher::PcodeCacher(void)
+
+{
+  // We aim to allocate this array only once
+  uint4 maxsize = 600;
+  poolstart = new VarnodeData[ maxsize ];
+  endpool = poolstart + maxsize;
+  curpool = poolstart;
+}
+
+PcodeCacher::~PcodeCacher(void)
+
+{
+  delete [] poolstart;
+}
+
+/// Expand the VarnodeData pool so that \e size more elements fit, and return
+/// a pointer to first available element.
+/// \param size is the number of elements to expand the pool by
+/// \return the first available VarnodeData
+VarnodeData *PcodeCacher::expandPool(uint4 size)
+
+{
+  uint4 curmax = endpool - poolstart;
+  uint4 cursize = curpool - poolstart;
+  if (cursize + size <= curmax)
+    return curpool;		// No expansion necessary
+  uint4 increase = (cursize + size) - curmax;
+  if (increase < 100)		// Increase by at least 100
+    increase = 100;
+
+  uint4 newsize = curmax + increase;
+
+  VarnodeData *newpool = new VarnodeData[newsize];
+  for(uint4 i=0;i<cursize;++i)
+    newpool[i] = poolstart[i];	// Copy old data
+  // Update references to the old pool
+  for(uint4 i=0;i<issued.size();++i) {
+    VarnodeData *outvar = issued[i].outvar;
+    if (outvar != (VarnodeData *)0) {
+      outvar = newpool + (outvar - poolstart);
+      issued[i].outvar = outvar;
+    }
+    VarnodeData *invar = issued[i].invar;
+    if (invar != (VarnodeData *)0) {
+      invar = newpool + (invar - poolstart);
+      issued[i].invar = invar;
+    }
+  }
+  list<RelativeRecord>::iterator iter;
+  for(iter=label_refs.begin();iter!=label_refs.end();++iter) {
+    VarnodeData *ref = (*iter).dataptr;
+    (*iter).dataptr = newpool + (ref - poolstart);
+  }
+  
+  delete [] poolstart;		// Free up old pool
+  poolstart = newpool;
+  curpool = newpool + (cursize + size);
+  endpool = newpool + newsize;
+  return newpool + cursize;
+}
+
+/// Store off a reference to the Varnode and the absolute index of the next
+/// instruction.  The Varnode must be an operand of the current instruction.
+/// \param ptr is the Varnode reference
+void PcodeCacher::addLabelRef(VarnodeData *ptr)
+
+{
+  label_refs.emplace_back();
+  label_refs.back().dataptr = ptr;
+  label_refs.back().calling_index = issued.size();
+}
+
+/// The label has an id that is referred to by Varnodes holding
+/// intra-instruction branch targets, prior to converting
+/// them to a \e relative \e branch offset.  The label is associated with
+/// the absolute index of the next PcodeData object to be issued,
+/// facilitating this conversion.
+/// \param id is the given id of the label
+void PcodeCacher::addLabel(uint4 id)
+
+{
+  while(labels.size() <= id)
+    labels.push_back(0xbadbeef);
+  labels[ id ] = issued.size();
+}
+
+void PcodeCacher::clear(void)
+
+{
+  curpool = poolstart;
+  issued.clear();
+  label_refs.clear();
+  labels.clear();
+}
+
+/// Assuming all the PcodeData has been generated for an
+/// instruction, go resolve any relative offsets and back
+/// patch their value(s) into the PcodeData
+void PcodeCacher::resolveRelatives(void)
+
+{
+  list<RelativeRecord>::const_iterator iter;
+  for(iter=label_refs.begin();iter!=label_refs.end();++iter) {
+    VarnodeData *ptr = (*iter).dataptr;
+    uint4 id = ptr->offset;
+    if ((id >= labels.size())||(labels[id] == 0xbadbeef))
+      throw LowlevelError("Reference to non-existant sleigh label");
+    // Calculate the relative index given the two absolute indices
+    uintb res = labels[id] - (*iter).calling_index;
+    res &= calc_mask( ptr->size );
+    ptr->offset = res;
+  }
+}
+
+/// Each p-code operation is presented to the emitter via its dump() method.
+/// \param addr is the Address associated with the p-code operation
+/// \param emt is the emitter
+void PcodeCacher::emit(const Address &addr,PcodeEmit *emt) const
+
+{
+  vector<PcodeData>::const_iterator iter;
+
+  for(iter=issued.begin();iter!=issued.end();++iter)
+    emt->dump(addr,(*iter).opc,(*iter).outvar,(*iter).invar,(*iter).isize);
+}
+
+/// \brief Generate a concrete VarnodeData object from the given template (VarnodeTpl)
+///
+/// \param vntpl is the template to reference
+/// \param vn is the object to fill in with concrete values
+void SleighBuilder::generateLocation(const VarnodeTpl *vntpl,VarnodeData &vn)
+
+{
+  vn.space = vntpl->getSpace().fixSpace(*walker);
+  vn.size = vntpl->getSize().fix(*walker);
+  if (vn.space == const_space)
+    vn.offset = vntpl->getOffset().fix(*walker) & calc_mask(vn.size);
+  else if (vn.space == uniq_space) {
+    vn.offset = vntpl->getOffset().fix(*walker);
+    vn.offset |= uniqueoffset;
+  }
+  else
+    vn.offset = vn.space->wrapOffset(vntpl->getOffset().fix(*walker));
+}
+
+/// \brief Generate a pointer VarnodeData from a dynamic template (VarnodeTpl)
+///
+/// The symbol represents a value referenced through a dynamic pointer.
+/// This method generates the varnode representing the pointer itself and also
+/// returns the address space in anticipation of generating the LOAD or STORE
+/// that actually manipulates the value.
+/// \param vntpl is the dynamic template to reference
+/// \param vn is the object to fill with concrete values
+/// \return the address space being pointed to
+AddrSpace *SleighBuilder::generatePointer(const VarnodeTpl *vntpl,VarnodeData &vn)
+
+{
+  const FixedHandle &hand(walker->getFixedHandle(vntpl->getOffset().getHandleIndex()));
+  vn.space = hand.offset_space;
+  vn.size = hand.offset_size;
+  if (vn.space == const_space)
+    vn.offset = hand.offset_offset & calc_mask(vn.size);
+  else if (vn.space == uniq_space)
+    vn.offset = hand.offset_offset | uniqueoffset;
+  else
+    vn.offset = vn.space->wrapOffset(hand.offset_offset);
+  return hand.space;
+}
+
+void SleighBuilder::generatePointerAdd(PcodeData *op,const VarnodeTpl *vntpl)
+
+{
+  uintb offsetPlus = vntpl->getOffset().getReal() & 0xffff;
+  if (offsetPlus == 0) {
+    return;
+  }
+  PcodeData *nextop = cache->allocateInstruction();
+  nextop->opc = op->opc;
+  nextop->invar = op->invar;
+  nextop->isize = op->isize;
+  nextop->outvar = op->outvar;
+  op->isize = 2;
+  op->opc = CPUI_INT_ADD;
+  VarnodeData *newparams = op->invar = cache->allocateVarnodes(2);
+  newparams[0] = nextop->invar[1];
+  newparams[1].space = const_space;	// Add in V_OFFSET_PLUS
+  newparams[1].offset = offsetPlus;
+  newparams[1].size = newparams[0].size;
+  op->outvar = nextop->invar + 1;	// Output of ADD is input to original op
+  op->outvar->space = uniq_space;		// Result of INT_ADD in special runtime temp
+  op->outvar->offset = uniq_space->getTrans()->getUniqueStart(Translate::RUNTIME_BITRANGE_EA);
+}
+
+void SleighBuilder::dump(OpTpl *op)
+
+{				// Dump on op through low-level dump interface
+				// filling in dynamic loads and stores if necessary
+  PcodeData *thisop;
+  VarnodeData *invars;
+  VarnodeData *loadvars;
+  VarnodeData *storevars;
+  VarnodeTpl *vn,*outvn;
+  int4 isize = op->numInput();
+				// First build all the inputs
+  invars = cache->allocateVarnodes(isize);
+  for(int4 i=0;i<isize;++i) {
+    vn = op->getIn(i);
+    if (vn->isDynamic(*walker)) {
+      generateLocation(vn,invars[i]); // Input of -op- is really temporary storage
+      PcodeData *load_op = cache->allocateInstruction();
+      load_op->opc = CPUI_LOAD;
+      load_op->outvar = invars + i;
+      load_op->isize = 2;
+      loadvars = load_op->invar = cache->allocateVarnodes(2);
+      AddrSpace *spc = generatePointer(vn,loadvars[1]);
+      loadvars[0].space = const_space;
+      loadvars[0].offset = (uintb)(uintp)spc;
+      loadvars[0].size = sizeof(spc);
+      if (vn->getOffset().getSelect() == ConstTpl::v_offset_plus)
+	generatePointerAdd(load_op, vn);
+    }
+    else
+      generateLocation(vn,invars[i]);
+  }
+  if ((isize>0)&&(op->getIn(0)->isRelative())) {
+    invars->offset += getLabelBase();
+    cache->addLabelRef(invars);
+  }
+  thisop = cache->allocateInstruction();
+  thisop->opc = op->getOpcode();
+  thisop->invar = invars;
+  thisop->isize = isize;
+  outvn = op->getOut();
+  if (outvn != (VarnodeTpl *)0) {
+    if (outvn->isDynamic(*walker)) {
+      storevars = cache->allocateVarnodes(3);
+      generateLocation(outvn,storevars[2]); // Output of -op- is really temporary storage
+      thisop->outvar = storevars+2;
+      PcodeData *store_op = cache->allocateInstruction();
+      store_op->opc = CPUI_STORE;
+      store_op->isize = 3;
+      // store_op->outvar = (VarnodeData *)0;
+      store_op->invar = storevars;
+      AddrSpace *spc = generatePointer(outvn,storevars[1]); // pointer
+      storevars[0].space = const_space;
+      storevars[0].offset = (uintb)(uintp)spc; // space in which to store
+      storevars[0].size = sizeof(spc);
+      if (outvn->getOffset().getSelect() == ConstTpl::v_offset_plus)
+	generatePointerAdd(store_op,outvn);
+    }
+    else {
+      thisop->outvar = cache->allocateVarnodes(1);
+      generateLocation(outvn,*thisop->outvar);
+    }
+  }
+}
+
+/// \brief Build a named p-code section of a constructor that contains only implied BUILD directives
+///
+/// If a named section of a constructor is empty, we still need to walk
+/// through any subtables that might contain p-code in their named sections.
+/// This method treats each subtable operand as an implied \e build directive,
+/// in the otherwise empty section.
+/// \param ct is the matching currently Constructor being built
+/// \param secnum is the particular \e named section number to build
+void SleighBuilder::buildEmpty(Constructor *ct,int4 secnum)
+
+{
+  int4 numops = ct->getNumOperands();
+  
+  for(int4 i=0;i<numops;++i) {
+    SubtableSymbol *sym = (SubtableSymbol *)ct->getOperand(i)->getDefiningSymbol();
+    if (sym == (SubtableSymbol *)0) continue;
+    if (sym->getType() != SleighSymbol::subtable_symbol) continue;
+
+    walker->pushOperand(i);
+    ConstructTpl *construct = walker->getConstructor()->getNamedTempl(secnum);
+    if (construct == (ConstructTpl *)0)
+      buildEmpty(walker->getConstructor(),secnum);
+    else
+      build(construct,secnum);
+    walker->popOperand();
+  }
+}
+
+/// Bits used to make temporary registers unique across multiple instructions
+/// are generated based on the given address.
+/// \param addr is the given Address
+void SleighBuilder::setUniqueOffset(const Address &addr)
+
+{
+  uniqueoffset = (addr.getOffset() & uniquemask)<<4;
+}
+
+/// \brief Constructor
+///
+/// \param w is the parsed instruction
+/// \param dcache is a cache of nearby instruction parses
+/// \param pc will hold the PcodeData and VarnodeData objects produced by \b this builder
+/// \param cspc is the constant address space
+/// \param uspc is the unique address space
+/// \param umask is the mask to use to find unique bits within an Address
+SleighBuilder::SleighBuilder(ParserWalker *w,DisassemblyCache *dcache,PcodeCacher *pc,AddrSpace *cspc,
+			     AddrSpace *uspc,uint4 umask)
+  : PcodeBuilder(0)
+{
+  walker = w;
+  discache = dcache;
+  cache = pc;
+  const_space = cspc;
+  uniq_space = uspc;
+  uniquemask = umask;
+  uniqueoffset = (walker->getAddr().getOffset() & uniquemask)<<4;
+}
+
+void SleighBuilder::appendBuild(OpTpl *bld,int4 secnum)
+
+{
+  // Append p-code for a particular build statement
+  int4 index = bld->getIn(0)->getOffset().getReal(); // Recover operand index from build statement
+				// Check if operand is a subtable
+  SubtableSymbol *sym = (SubtableSymbol *)walker->getConstructor()->getOperand(index)->getDefiningSymbol();
+  if ((sym==(SubtableSymbol *)0)||(sym->getType() != SleighSymbol::subtable_symbol)) return;
+  
+  walker->pushOperand(index);
+  Constructor *ct = walker->getConstructor();
+  if (secnum >=0) {
+    ConstructTpl *construct = ct->getNamedTempl(secnum);
+    if (construct == (ConstructTpl *)0)
+      buildEmpty(ct,secnum);
+    else
+      build(construct,secnum);
+  }
+  else {
+    ConstructTpl *construct = ct->getTempl();
+    build(construct,-1);
+  }
+  walker->popOperand();
+}
+
+void SleighBuilder::delaySlot(OpTpl *op)
+
+{
+  // Append pcode for an entire instruction (delay slot)
+  // in the middle of the current instruction
+  ParserWalker *tmp = walker;
+  uintb olduniqueoffset = uniqueoffset;
+
+  Address baseaddr = tmp->getAddr();
+  int4 fallOffset = tmp->getLength();
+  int4 delaySlotByteCnt = tmp->getParserContext()->getDelaySlot();
+  int4 bytecount = 0;
+  do {
+    Address newaddr = baseaddr + fallOffset;
+    setUniqueOffset(newaddr);
+    const ParserContext *pos = discache->getParserContext(newaddr);
+    if (pos->getParserState() != ParserContext::pcode)
+      throw LowlevelError("Could not obtain cached delay slot instruction");
+    int4 len = pos->getLength();
+
+    ParserWalker newwalker( pos );
+    walker = &newwalker;
+    walker->baseState();
+    build(walker->getConstructor()->getTempl(),-1); // Build the whole delay slot
+    fallOffset += len;
+    bytecount += len;
+  } while(bytecount < delaySlotByteCnt);
+  walker = tmp;			// Restore original context
+  uniqueoffset = olduniqueoffset;
+}
+
+void SleighBuilder::setLabel(OpTpl *op)
+
+{
+  cache->addLabel( op->getIn(0)->getOffset().getReal()+getLabelBase() );
+}
+
+void SleighBuilder::appendCrossBuild(OpTpl *bld,int4 secnum)
+
+{
+  // Weave in the p-code section from an instruction at another address
+  // bld-param(0) contains the address of the instruction
+  // bld-param(1) contains the section number
+  if (secnum>=0)
+    throw LowlevelError("CROSSBUILD directive within a named section");
+  secnum = bld->getIn(1)->getOffset().getReal();
+  VarnodeTpl *vn = bld->getIn(0);
+  AddrSpace *spc = vn->getSpace().fixSpace(*walker);
+  uintb addr = spc->wrapOffset( vn->getOffset().fix(*walker) );
+
+  ParserWalker *tmp = walker;
+  uintb olduniqueoffset = uniqueoffset;
+
+  Address newaddr(spc,addr);
+  setUniqueOffset(newaddr);
+  const ParserContext *pos = discache->getParserContext( newaddr );
+  if (pos->getParserState() != ParserContext::pcode)
+    throw LowlevelError("Could not obtain cached crossbuild instruction");
+  
+  ParserWalker newwalker( pos, tmp->getParserContext() );
+  walker = &newwalker;
+
+  walker->baseState();
+  Constructor *ct = walker->getConstructor();
+  ConstructTpl *construct = ct->getNamedTempl(secnum);
+  if (construct == (ConstructTpl *)0)
+    buildEmpty(ct,secnum);
+  else
+    build(construct,secnum);
+  walker = tmp;
+  uniqueoffset = olduniqueoffset;
+}
+
+/// \param min is the minimum number of allocations before a reuse is expected
+/// \param hashsize is the number of elements in the hash-table
+void DisassemblyCache::initialize(int4 min,int4 hashsize)
+
+{
+  minimumreuse = min;
+  mask = hashsize-1;
+  uintb masktest = coveringmask((uintb)mask);
+  if (masktest != (uintb)mask)	// -hashsize- must be a power of 2
+    throw LowlevelError("Bad windowsize for disassembly cache");
+  list = new ParserContext *[minimumreuse];
+  nextfree = 0;
+  hashtable = new ParserContext *[hashsize];
+  for(int4 i=0;i<minimumreuse;++i) {
+    ParserContext *pos = new ParserContext(contextcache);
+    pos->initialize(75,20,constspace);
+    list[i] = pos;
+  }
+  ParserContext *pos = list[0];
+  for(int4 i=0;i<hashsize;++i)
+    hashtable[i] = pos;		// Make sure all hashtable positions point to a real ParserContext
+}
+
+void DisassemblyCache::free(void)
+
+{
+  for(int4 i=0;i<minimumreuse;++i)
+    delete list[i];
+  delete [] list;
+  delete [] hashtable;
+}
+
+/// \param ccache is the ContextCache front-end shared across all the parser contexts
+/// \param cspace is the constant address space used for minting constant Varnodes
+/// \param cachesize is the number of distinct ParserContext objects in this cache
+/// \param windowsize is the size of the ParserContext hash-table
+DisassemblyCache::DisassemblyCache(ContextCache *ccache,AddrSpace *cspace,int4 cachesize,int4 windowsize)
+
+{
+  contextcache = ccache;
+  constspace = cspace;
+  initialize(cachesize,windowsize);		// Set default settings for the cache
+}
+
+/// Return a (possibly cached) ParserContext that is associated with \e addr
+/// If n different calls to this interface are made with n different Addresses, if
+///    - n <= minimumreuse   AND
+///    - all the addresses are within the windowsize (=mask+1)
+///
+/// then the cacher guarantees that you get all different ParserContext objects
+/// \param addr is the Address to disassemble at
+/// \return the ParserContext associated with the address
+ParserContext *DisassemblyCache::getParserContext(const Address &addr)
+
+{
+  int4 hashindex = ((int4) addr.getOffset()) & mask;
+  ParserContext *res = hashtable[ hashindex ];
+  if (res->getAddr() == addr)
+    return res;
+  res = list[ nextfree ];
+  nextfree += 1;		// Advance the circular index
+  if (nextfree >= minimumreuse)
+    nextfree = 0;
+  res->setAddr(addr);
+  res->setParserState(ParserContext::uninitialized);	// Need to start over with parsing
+  hashtable[ hashindex ] = res;	// Stick it into the hashtable
+  return res;
+}
 
 /// \param ld is the LoadImage to draw program bytes from
 /// \param c_db is the context database
-SleighMishegos::SleighMishegos(LoadImage *ld, ContextDatabase *c_db) : SleighBase() {
+SleighMishegos::SleighMishegos(LoadImage *ld,ContextDatabase *c_db)
+  : SleighBase()
+
+{
   loader = ld;
   context_db = c_db;
   cache = new ContextCache(c_db);
-  pos = nullptr;
+  discache = (DisassemblyCache *)0;
+  pos = (ParserContext *)0;
 }
 
-void SleighMishegos::clearForDelete(void) {
+void SleighMishegos::clearForDelete(void)
+
+{
   delete cache;
-  delete pos;
+  if (discache != (DisassemblyCache *)0)
+    delete discache;
+  if (pos != (ParserContext *)0)
+    delete pos;
 }
 
-SleighMishegos::~SleighMishegos(void) {
+SleighMishegos::~SleighMishegos(void)
+
+{
   clearForDelete();
 }
 
@@ -46,27 +544,40 @@ SleighMishegos::~SleighMishegos(void) {
 /// with a new LoadImage and ContextDatabase
 /// \param ld is the new LoadImage
 /// \param c_db is the new ContextDatabase
-void SleighMishegos::reset(LoadImage *ld, ContextDatabase *c_db) {
+void SleighMishegos::reset(LoadImage *ld,ContextDatabase *c_db)
+
+{
   clearForDelete();
+  pcode_cache.clear();
   loader = ld;
   context_db = c_db;
   cache = new ContextCache(c_db);
+  discache = (DisassemblyCache *)0;
+  pos = (ParserContext *)0;
 }
 
 /// The .sla file from the document store is loaded and cache objects are prepared
 /// \param store is the document store containing the main \<sleigh> tag.
-void SleighMishegos::initialize(DocumentStorage &store) {
-  if (!isInitialized()) { // Initialize the base if not already
+void SleighMishegos::initialize(DocumentStorage &store)
+
+{
+  if (!isInitialized()) {	// Initialize the base if not already
     const Element *el = store.getTag("sleigh");
     if (el == (const Element *)0)
       throw LowlevelError("Could not find sleigh tag");
     restoreXml(el);
-  } else
+  }
+  else
     reregisterContext();
-
+  uint4 parser_cachesize = 2;
+  uint4 parser_windowsize = 32;
+  if ((maxdelayslotbytes > 1)||(unique_allocatemask != 0)) {
+    parser_cachesize = 8;
+    parser_windowsize = 256;
+  }
   pos = new ParserContext(cache);
-
-  // Values taken from DisassemblyCache::initialize
+  // Values taken from (now removed) DisassemblyCache::initialize. No
+  // explanation for magic values
   pos->initialize(75, 20, getConstantSpace());
 }
 
@@ -79,156 +590,227 @@ void SleighMishegos::initialize(DocumentStorage &store) {
 /// \param addr is the given address of the instruction
 /// \param state is the desired parse state.
 /// \return the parse tree object (ParseContext)
-ParserContext *SleighMishegos::obtainContext(const Address &addr, int4 state) const {
+ParserContext *SleighMishegos::obtainContext(const Address &addr,int4 state) const
+
+{
   pos->setAddr(addr);
   pos->setParserState(ParserContext::uninitialized);
-
-  resolve(*pos);
-  if (state == ParserContext::disassembly)
+  int4 curstate = pos->getParserState();
+  if (curstate >= state)
     return pos;
-
+  if (curstate == ParserContext::uninitialized) {
+    resolve(*pos);
+    if (state == ParserContext::disassembly)
+      return pos;
+  }
   // If we reach here,  state must be ParserContext::pcode
   resolveHandles(*pos);
   return pos;
 }
 
 /// Resolve \e all the constructors involved in the instruction at the indicated address
-/// \param pc is the parse object that will hold the resulting tree
-void SleighMishegos::resolve(ParserContext &pc) const {
-  loader->loadFill(pc.getBuffer(), 16, pc.getAddr());
-  ParserWalkerChange walker(&pc);
-  pc.deallocateState(walker); // Clear the previous resolve and initialize the walker
-  Constructor *ct, *subct;
-  uint4 off;
-  int4 oper, numoper;
+/// \param pos is the parse object that will hold the resulting tree
+void SleighMishegos::resolve(ParserContext &pos) const
 
-  pc.setDelaySlot(0);
-  walker.setOffset(0);        // Initial offset
-  pc.clearCommits();          // Clear any old context commits
-  pc.loadContext();           // Get context for current address
-  ct = root->resolve(walker); // Base constructor
+{
+  loader->loadFill(pos.getBuffer(),16,pos.getAddr());
+  ParserWalkerChange walker(&pos);
+  pos.deallocateState(walker);	// Clear the previous resolve and initialize the walker
+  Constructor *ct,*subct;
+  uint4 off;
+  int4 oper,numoper;
+
+  pos.setDelaySlot(0);
+  walker.setOffset(0);		// Initial offset
+  pos.clearCommits();		// Clear any old context commits
+  pos.loadContext();		// Get context for current address
+  ct = root->resolve(walker);	// Base constructor
   walker.setConstructor(ct);
   ct->applyContext(walker);
-  while (walker.isState()) {
+  while(walker.isState()) {
     ct = walker.getConstructor();
     oper = walker.getOperand();
     numoper = ct->getNumOperands();
-    while (oper < numoper) {
+    while(oper < numoper) {
       OperandSymbol *sym = ct->getOperand(oper);
       off = walker.getOffset(sym->getOffsetBase()) + sym->getRelativeOffset();
-      pc.allocateOperand(oper, walker); // Descend into new operand and reserve space
+      pos.allocateOperand(oper,walker); // Descend into new operand and reserve space
       walker.setOffset(off);
       TripleSymbol *tsym = sym->getDefiningSymbol();
       if (tsym != (TripleSymbol *)0) {
-        subct = tsym->resolve(walker);
-        if (subct != (Constructor *)0) {
-          walker.setConstructor(subct);
-          subct->applyContext(walker);
-          break;
-        }
+	subct = tsym->resolve(walker);
+	if (subct != (Constructor *)0) {
+	  walker.setConstructor(subct);
+	  subct->applyContext(walker);
+	  break;
+	}
       }
       walker.setCurrentLength(sym->getMinimumLength());
       walker.popOperand();
       oper += 1;
     }
     if (oper >= numoper) { // Finished processing constructor
-      walker.calcCurrentLength(ct->getMinimumLength(), numoper);
+      walker.calcCurrentLength(ct->getMinimumLength(),numoper);
       walker.popOperand();
-      // Check for use of delayslot
+				// Check for use of delayslot
       ConstructTpl *templ = ct->getTempl();
-      if ((templ != (ConstructTpl *)0) && (templ->delaySlot() > 0))
-        pc.setDelaySlot(templ->delaySlot());
+      if ((templ != (ConstructTpl *)0)&&(templ->delaySlot() > 0))
+	pos.setDelaySlot(templ->delaySlot());
     }
   }
-  pc.setNaddr(pc.getAddr() + pc.getLength()); // Update Naddr to pointer after instruction
-  pc.setParserState(ParserContext::disassembly);
+  pos.setNaddr(pos.getAddr()+pos.getLength());	// Update Naddr to pointer after instruction
+  pos.setParserState(ParserContext::disassembly);
 }
 
 /// Resolve handle templates for the given parse tree, assuming Constructors
 /// are already resolved.
-/// \param pc is the given parse tree
-void SleighMishegos::resolveHandles(ParserContext &pc) const {
+/// \param pos is the given parse tree
+void SleighMishegos::resolveHandles(ParserContext &pos) const
+
+{
   TripleSymbol *triple;
   Constructor *ct;
-  int4 oper, numoper;
+  int4 oper,numoper;
 
-  ParserWalker walker(&pc);
+  ParserWalker walker(&pos);
   walker.baseState();
-  while (walker.isState()) {
+  while(walker.isState()) {
     ct = walker.getConstructor();
     oper = walker.getOperand();
     numoper = ct->getNumOperands();
-    while (oper < numoper) {
+    while(oper < numoper) {
       OperandSymbol *sym = ct->getOperand(oper);
-      walker.pushOperand(oper); // Descend into node
+      walker.pushOperand(oper);	// Descend into node
       triple = sym->getDefiningSymbol();
       if (triple != (TripleSymbol *)0) {
-        if (triple->getType() == SleighSymbol::subtable_symbol)
-          break;
-        else // Some other kind of symbol as an operand
-          triple->getFixedHandle(walker.getParentHandle(), walker);
-      } else { // Must be an expression
-        PatternExpression *patexp = sym->getDefiningExpression();
-        intb res = patexp->getValue(walker);
-        FixedHandle &hand(walker.getParentHandle());
-        hand.space = pc.getConstSpace(); // Result of expression is a constant
-        hand.offset_space = (AddrSpace *)0;
-        hand.offset_offset = (uintb)res;
-        hand.size = 0; // This size should not get used
+	if (triple->getType() == SleighSymbol::subtable_symbol)
+	  break;
+	else			// Some other kind of symbol as an operand
+	  triple->getFixedHandle(walker.getParentHandle(),walker);
+      }
+      else {			// Must be an expression
+	PatternExpression *patexp = sym->getDefiningExpression();
+	intb res = patexp->getValue(walker);
+	FixedHandle &hand(walker.getParentHandle());
+	hand.space = pos.getConstSpace(); // Result of expression is a constant
+	hand.offset_space = (AddrSpace *)0;
+	hand.offset_offset = (uintb)res;
+	hand.size = 0;		// This size should not get used
       }
       walker.popOperand();
       oper += 1;
     }
-    if (oper >= numoper) { // Finished processing constructor
+    if (oper >= numoper) {	// Finished processing constructor
       ConstructTpl *templ = ct->getTempl();
       if (templ != (ConstructTpl *)0) {
-        HandleTpl *res = templ->getResult();
-        if (res != (HandleTpl *)0) // Pop up handle to containing operand
-          res->fix(walker.getParentHandle(), walker);
-        // If we need an indicator that the constructor exports nothing try
+	HandleTpl *res = templ->getResult();
+	if (res != (HandleTpl *)0)	// Pop up handle to containing operand
+	  res->fix(walker.getParentHandle(),walker);
+	// If we need an indicator that the constructor exports nothing try
         // else
-        //   walker.getParentHandle().setInvalid();
+	//   walker.getParentHandle().setInvalid();
       }
       walker.popOperand();
     }
   }
-  pc.setParserState(ParserContext::pcode);
+  pos.setParserState(ParserContext::pcode);
 }
 
-int4 SleighMishegos::instructionLength(const Address &baseaddr) const {
-  ParserContext *pc = obtainContext(baseaddr, ParserContext::disassembly);
-  return pc->getLength();
+int4 SleighMishegos::instructionLength(const Address &baseaddr) const
+
+{
+  ParserContext *pos = obtainContext(baseaddr,ParserContext::disassembly);
+  return pos->getLength();
 }
 
-int4 SleighMishegos::printAssembly(AssemblyEmit &emit, const Address &baseaddr) const {
+int4 SleighMishegos::printAssembly(AssemblyEmit &emit,const Address &baseaddr) const
+
+{
   int4 sz;
 
-  ParserContext *pc = obtainContext(baseaddr, ParserContext::disassembly);
-  ParserWalker walker(pc);
+  ParserContext *pos = obtainContext(baseaddr,ParserContext::disassembly);
+  ParserWalker walker(pos);
   walker.baseState();
-
+  
   Constructor *ct = walker.getConstructor();
   ostringstream mons;
-  ct->printMnemonic(mons, walker);
+  ct->printMnemonic(mons,walker);
   ostringstream body;
-  ct->printBody(body, walker);
-  emit.dump(baseaddr, mons.str(), body.str());
-  sz = pc->getLength();
+  ct->printBody(body,walker);
+  emit.dump(baseaddr,mons.str(),body.str());
+  sz = pos->getLength();
   return sz;
 }
 
-int4 SleighMishegos::oneInstruction(PcodeEmit &, const Address &) const {
+int4 SleighMishegos::oneInstruction(PcodeEmit &emit,const Address &baseaddr) const
+
+{
   throw UnimplError("Unimplemented oneInstruction", 0);
+  int4 fallOffset;
+  if (alignment != 1) {
+    if ((baseaddr.getOffset() % alignment)!=0) {
+      ostringstream s;
+      s << "Instruction address not aligned: " << baseaddr;
+      throw UnimplError(s.str(),0);
+    }
+  }
+  
+  ParserContext *pos = obtainContext(baseaddr,ParserContext::pcode);
+  pos->applyCommits();
+  fallOffset = pos->getLength();
+  
+  if (pos->getDelaySlot()>0) {
+    int4 bytecount = 0;
+    do {
+    // Do not pass pos->getNaddr() to obtainContext, as pos may have been previously cached and had naddr adjusted
+      ParserContext *delaypos = obtainContext(pos->getAddr() + fallOffset,ParserContext::pcode);
+      delaypos->applyCommits();
+      int4 len = delaypos->getLength();
+      fallOffset += len;
+      bytecount += len;
+    } while(bytecount < pos->getDelaySlot());
+    pos->setNaddr(pos->getAddr()+fallOffset);
+  }
+  ParserWalker walker(pos);
+  walker.baseState();
+  pcode_cache.clear();
+  SleighBuilder builder(&walker,discache,&pcode_cache,getConstantSpace(),getUniqueSpace(),unique_allocatemask);
+  try {
+    builder.build(walker.getConstructor()->getTempl(),-1);
+    pcode_cache.resolveRelatives();
+    pcode_cache.emit(baseaddr,&emit);
+  } catch(UnimplError &err) {
+    ostringstream s;
+    s << "Instruction not implemented in pcode:\n ";
+    ParserWalker *cur = builder.getCurrentWalker();
+    cur->baseState();
+    Constructor *ct = cur->getConstructor();
+    cur->getAddr().printRaw(s);
+    s << ": ";
+    ct->printMnemonic(s,*cur);
+    s << "  ";
+    ct->printBody(s,*cur);
+    err.explain = s.str();
+    err.instruction_length = fallOffset;
+    throw err;
+  }
+  return fallOffset;
 }
 
-void SleighMishegos::registerContext(const string &name, int4 sbit, int4 ebit) {
-  context_db->registerVariable(name, sbit, ebit);
+void SleighMishegos::registerContext(const string &name,int4 sbit,int4 ebit)
+
+{
+  context_db->registerVariable(name,sbit,ebit);
 }
 
-void SleighMishegos::setContextDefault(const string &name, uintm val) {
-  context_db->setVariableDefault(name, val);
+void SleighMishegos::setContextDefault(const string &name,uintm val)
+
+{
+  context_db->setVariableDefault(name,val);
 }
 
-void SleighMishegos::allowContextSet(bool val) const {
+void SleighMishegos::allowContextSet(bool val) const
+
+{
   cache->allowSet(val);
 }

--- a/src/worker/ghidra/sleighMishegos.hh
+++ b/src/worker/ghidra/sleighMishegos.hh
@@ -1,0 +1,46 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This class was copied from upstream
+ * https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh.hh
+ *
+ * Modified by Eric Kilmer at Trail of Bits 2021
+ * Modified to better support mishegos single-shot disassembly by removing the
+ * caching of disassembly results at the same address without having to
+ * reinitialize the class.
+ */
+#include <sleigh/sleighbase.hh>
+#include <sleigh/loadimage.hh>
+
+class SleighMishegos : public SleighBase {
+  LoadImage *loader;			///< The mapped bytes in the program
+  ContextDatabase *context_db;		///< Database of context values steering disassembly
+  ContextCache *cache;			///< Cache of recently used context values
+  ParserContext *pos;
+  void clearForDelete(void);		///< Delete the context and disassembly caches
+protected:
+  ParserContext *obtainContext(const Address &addr,int4 state) const;
+  void resolve(ParserContext &pos) const;	///< Generate a parse tree suitable for disassembly
+  void resolveHandles(ParserContext &pos) const;	///< Prepare the parse tree for p-code generation
+public:
+  SleighMishegos(LoadImage *ld,ContextDatabase *c_db);		///< Constructor
+  virtual ~SleighMishegos(void);				///< Destructor
+  void reset(LoadImage *ld,ContextDatabase *c_db);	///< Reset the engine for a new program
+  virtual void initialize(DocumentStorage &store);
+  virtual void registerContext(const string &name,int4 sbit,int4 ebit);
+  virtual void setContextDefault(const string &nm,uintm val);
+  virtual void allowContextSet(bool val) const;
+  virtual int4 instructionLength(const Address &baseaddr) const;
+  virtual int4 oneInstruction(PcodeEmit &emit,const Address &baseaddr) const;
+  virtual int4 printAssembly(AssemblyEmit &emit,const Address &baseaddr) const;
+};

--- a/src/worker/ghidra/sleighMishegos.hh
+++ b/src/worker/ghidra/sleighMishegos.hh
@@ -23,22 +23,22 @@
 #include <sleigh/loadimage.hh>
 
 class SleighMishegos : public SleighBase {
-  LoadImage *loader;			///< The mapped bytes in the program
-  ContextDatabase *context_db;		///< Database of context values steering disassembly
-  ContextCache *cache;			///< Cache of recently used context values
+  LoadImage *loader;           ///< The mapped bytes in the program
+  ContextDatabase *context_db; ///< Database of context values steering disassembly
+  ContextCache *cache;         ///< Cache of recently used context values
   ParserContext *pos;
-  void clearForDelete(void);		///< Delete the context and disassembly caches
+  void clearForDelete(void); ///< Delete the context and disassembly caches
 protected:
-  ParserContext *obtainContext(const Address &addr,int4 state) const;
-  void resolve(ParserContext &pc) const;	///< Generate a parse tree suitable for disassembly
-  void resolveHandles(ParserContext &pc) const;	///< Prepare the parse tree for p-code generation
+  ParserContext *obtainContext(const Address &addr, int4 state) const;
+  void resolve(ParserContext &pc) const;        ///< Generate a parse tree suitable for disassembly
+  void resolveHandles(ParserContext &pc) const; ///< Prepare the parse tree for p-code generation
 public:
-  SleighMishegos(LoadImage *ld,ContextDatabase *c_db);		///< Constructor
-  ~SleighMishegos(void) override;				///< Destructor
-  void reset(LoadImage *ld,ContextDatabase *c_db);	///< Reset the engine for a new program
+  SleighMishegos(LoadImage *ld, ContextDatabase *c_db); ///< Constructor
+  ~SleighMishegos(void) override;                       ///< Destructor
+  void reset(LoadImage *ld, ContextDatabase *c_db);     ///< Reset the engine for a new program
   void initialize(DocumentStorage &store) override;
-  void registerContext(const string &name,int4 sbit,int4 ebit) override;
-  void setContextDefault(const string &nm,uintm val) override;
+  void registerContext(const string &name, int4 sbit, int4 ebit) override;
+  void setContextDefault(const string &nm, uintm val) override;
   void allowContextSet(bool val) const override;
   int4 instructionLength(const Address &baseaddr) const override;
   int4 oneInstruction(PcodeEmit &emit, const Address &baseaddr) const override;

--- a/src/worker/ghidra/sleighMishegos.hh
+++ b/src/worker/ghidra/sleighMishegos.hh
@@ -1,46 +1,537 @@
-/**
+/* ###
+ * IP: GHIDRA
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * This class was copied from upstream
- * https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh.hh
+ * This file was copied from upstream
+ * https://github.com/NationalSecurityAgency/ghidra/blob/47f76c78d6b7d5c56a9256b0666620863805ff30/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh.hh
  *
- * Modified by Eric Kilmer at Trail of Bits 2021
- * Modified to better support mishegos single-shot disassembly by removing the
- * caching of disassembly results at the same address without having to
- * reinitialize the class.
+ * Modified by Eric Kilmer at Trail of Bits 2022
+ * Modified to better support mishegos single-shot disassembly by not using the
+ * disassembly cache. This allows us to get new disassembly results at the same
+ * address without having to reinitialize everything.
+ *
+ * This file has been modified in a way to minimize the diff from upstream.
+ * There is dead code and other code artifacts that probably wouldn't be
+ * written in the same way had this functionality been written fresh.
  */
-#include <sleigh/sleighbase.hh>
-#include <sleigh/loadimage.hh>
+/// \file sleigh.hh
+/// \brief Classes and utilities for the main SLEIGH engine
 
-class SleighMishegos : public SleighBase {
-  LoadImage *loader;           ///< The mapped bytes in the program
-  ContextDatabase *context_db; ///< Database of context values steering disassembly
-  ContextCache *cache;         ///< Cache of recently used context values
-  ParserContext *pos;
-  void clearForDelete(void); ///< Delete the context and disassembly caches
-protected:
-  ParserContext *obtainContext(const Address &addr, int4 state) const;
-  void resolve(ParserContext &pc) const;        ///< Generate a parse tree suitable for disassembly
-  void resolveHandles(ParserContext &pc) const; ///< Prepare the parse tree for p-code generation
-public:
-  SleighMishegos(LoadImage *ld, ContextDatabase *c_db); ///< Constructor
-  ~SleighMishegos(void) override;                       ///< Destructor
-  void reset(LoadImage *ld, ContextDatabase *c_db);     ///< Reset the engine for a new program
-  void initialize(DocumentStorage &store) override;
-  void registerContext(const string &name, int4 sbit, int4 ebit) override;
-  void setContextDefault(const string &nm, uintm val) override;
-  void allowContextSet(bool val) const override;
-  int4 instructionLength(const Address &baseaddr) const override;
-  int4 oneInstruction(PcodeEmit &emit, const Address &baseaddr) const override;
-  int4 printAssembly(AssemblyEmit &emit, const Address &baseaddr) const override;
+#ifndef __SLEIGHMISHEGOS__
+#define __SLEIGHMISHEGOS__
+
+#include <sleigh/sleighbase.hh>
+
+class LoadImage;
+
+/// \brief Class for describing a relative p-code branch destination
+///
+/// An intra-instruction p-code branch takes a \e relative operand.
+/// The actual value produced during p-code generation is calculated at
+/// the last second using \b this. It stores the index of the BRANCH
+/// instruction and a reference to its destination operand. This initially
+/// holds a reference to a destination \e label symbol, but is later updated
+/// with the final relative value.
+struct RelativeRecord {
+  VarnodeData *dataptr;		///< Varnode indicating relative offset
+  uintb calling_index;		///< Index of instruction containing relative offset
 };
+
+/// \brief Data for building one p-code instruction
+///
+/// Raw data used by the emitter to produce a single PcodeOp
+struct PcodeData {
+  OpCode opc;			///< The op code
+  VarnodeData *outvar;	     	///< Output Varnode data (or null)
+  VarnodeData *invar;		///< Array of input Varnode data
+  int4 isize;			///< Number of input Varnodes
+};
+
+/// \brief Class for caching a chunk of p-code, prior to emitting
+///
+/// The engine accumulates PcodeData and VarnodeData objects for
+/// a single instruction.  Once the full instruction is constructed,
+/// the objects are passed to the emitter (PcodeEmit) via the emit() method.
+/// The class acts as a pool of memory for PcodeData and VarnodeData objects
+/// that can be reused repeatedly to emit multiple instructions.
+class PcodeCacher {
+  VarnodeData *poolstart;		///< Start of the pool of VarnodeData objects
+  VarnodeData *curpool;			///< First unused VarnodeData
+  VarnodeData *endpool;			///< End of the pool of VarnodeData objects
+  vector<PcodeData> issued;		///< P-code ops issued for the current instruction
+  list<RelativeRecord> label_refs;	///< References to labels
+  vector<uintb> labels;			///< Locations of labels
+  VarnodeData *expandPool(uint4 size);	///< Expand the memory pool
+public:
+  PcodeCacher(void);		///< Constructor
+  ~PcodeCacher(void);		///< Destructor
+
+  /// \brief Allocate data objects for a new set of Varnodes
+  ///
+  /// \param size is the number of objects to allocate
+  /// \return a pointer to the array of available VarnodeData objects
+  VarnodeData *allocateVarnodes(uint4 size) {
+    VarnodeData *newptr = curpool + size;
+    if (newptr <= endpool) {
+      VarnodeData *res = curpool;
+      curpool = newptr;
+      return res;
+    }
+    return expandPool(size);
+  }
+
+  /// \brief Allocate a data object for a new p-code operation
+  ///
+  /// \return the new PcodeData object
+  PcodeData *allocateInstruction(void) {
+    issued.emplace_back();
+    PcodeData *res = &issued.back();
+    res->outvar = (VarnodeData *)0;
+    res->invar = (VarnodeData *)0;
+    return res;
+  }
+  void addLabelRef(VarnodeData *ptr);	///< Denote a Varnode holding a \e relative \e branch offset
+  void addLabel(uint4 id);		///< Attach a label to the \e next p-code instruction
+  void clear(void);			///< Reset the cache so that all objects are unallocated
+  void resolveRelatives(void);		///< Rewrite branch target Varnodes as \e relative offsets
+  void emit(const Address &addr,PcodeEmit *emt) const;	///< Pass the cached p-code data to the emitter
+};
+
+/// \brief A container for disassembly context used by the SLEIGH engine
+///
+/// This acts as a factor for the ParserContext objects which are used to disassemble
+/// a single instruction.  These all share a ContextCache which is a front end for
+/// accessing the ContextDatabase and resolving context variables from the SLEIGH spec.
+/// ParserContext objects are stored in a hash-table keyed by the address of the instruction.
+class DisassemblyCache {
+  ContextCache *contextcache;	///< Cached values from the ContextDatabase
+  AddrSpace *constspace;	///< The constant address space
+  int4 minimumreuse;		///< Can call getParserContext this many times, before a ParserContext is reused
+  uint4 mask;			///< Size of the hashtable in form 2^n-1
+  ParserContext **list;		///< (circular) array of currently cached ParserContext objects
+  int4 nextfree;		///< Current end/beginning of circular list
+  ParserContext **hashtable;	///< Hashtable for looking up ParserContext via Address
+  void initialize(int4 min,int4 hashsize);	///< Initialize the hash-table of ParserContexts
+  void free(void);		///< Free the hash-table of ParserContexts
+public:
+  DisassemblyCache(ContextCache *ccache,AddrSpace *cspace,int4 cachesize,int4 windowsize);	///< Constructor
+  ~DisassemblyCache(void) { free(); }	///< Destructor
+  ParserContext *getParserContext(const Address &addr);		///< Get the parser for a particular Address
+};
+
+/// \brief Build p-code from a pre-parsed instruction
+///
+/// Through the build() method, \b this walks the parse tree and prepares data
+/// for final emission as p-code.  (The final emitting is done separately through the
+/// PcodeCacher.emit() method).  Generally, only p-code for one instruction is prepared.
+/// But, through the \b delay-slot mechanism, build() may recursively visit
+/// additional instructions.
+class SleighBuilder : public PcodeBuilder {
+  virtual void dump( OpTpl *op );
+  AddrSpace *const_space;		///< The constant address space
+  AddrSpace *uniq_space;		///< The unique address space
+  uintb uniquemask;			///< Mask of address bits to use to uniquify temporary registers
+  uintb uniqueoffset;			///< Uniquifier bits for \b this instruction
+  DisassemblyCache *discache;		///< Cache of disassembled instructions
+  PcodeCacher *cache;			///< Cache accumulating p-code data for the instruction
+  void buildEmpty(Constructor *ct,int4 secnum);
+  void generateLocation(const VarnodeTpl *vntpl,VarnodeData &vn);
+  AddrSpace *generatePointer(const VarnodeTpl *vntpl,VarnodeData &vn);
+  void generatePointerAdd(PcodeData *op,const VarnodeTpl *vntpl);
+  void setUniqueOffset(const Address &addr);	///< Set uniquifying bits for the current instruction
+public:
+  SleighBuilder(ParserWalker *w,DisassemblyCache *dcache,PcodeCacher *pc,AddrSpace *cspc,AddrSpace *uspc,uint4 umask);
+  virtual void appendBuild(OpTpl *bld,int4 secnum);
+  virtual void delaySlot(OpTpl *op);
+  virtual void setLabel(OpTpl *op);
+  virtual void appendCrossBuild(OpTpl *bld,int4 secnum);
+};
+
+/// \brief A full SLEIGH engine
+///
+/// Its provided with a LoadImage of the bytes to be disassembled and
+/// a ContextDatabase.
+///
+/// Assembly is produced via the printAssembly() method, provided with an
+/// AssemblyEmit object and an Address.
+///
+/// P-code is produced via the oneInstruction() method, provided with a PcodeEmit
+/// object and an Address.
+class SleighMishegos : public SleighBase {
+  LoadImage *loader;			///< The mapped bytes in the program
+  ContextDatabase *context_db;		///< Database of context values steering disassembly
+  ContextCache *cache;			///< Cache of recently used context values
+  mutable DisassemblyCache *discache;	///< Cache of recently parsed instructions
+  mutable PcodeCacher pcode_cache;	///< Cache of p-code data just prior to emitting
+  ParserContext *pos;
+  void clearForDelete(void);		///< Delete the context and disassembly caches
+protected:
+  ParserContext *obtainContext(const Address &addr,int4 state) const;
+  void resolve(ParserContext &pos) const;	///< Generate a parse tree suitable for disassembly
+  void resolveHandles(ParserContext &pos) const;	///< Prepare the parse tree for p-code generation
+public:
+  SleighMishegos(LoadImage *ld,ContextDatabase *c_db);		///< Constructor
+  virtual ~SleighMishegos(void);				///< Destructor
+  void reset(LoadImage *ld,ContextDatabase *c_db);	///< Reset the engine for a new program
+  virtual void initialize(DocumentStorage &store);
+  virtual void registerContext(const string &name,int4 sbit,int4 ebit);
+  virtual void setContextDefault(const string &nm,uintm val);
+  virtual void allowContextSet(bool val) const;
+  virtual int4 instructionLength(const Address &baseaddr) const;
+  virtual int4 oneInstruction(PcodeEmit &emit,const Address &baseaddr) const;
+  virtual int4 printAssembly(AssemblyEmit &emit,const Address &baseaddr) const;
+};
+
+/** \page sleigh SLEIGH
+
+  \section sleightoc Table of Contents
+
+    - \ref sleighoverview
+    - \ref sleighbuild
+    - \ref sleighuse
+    - \subpage sleighAPIbasic
+    - \subpage sleighAPIemulate
+
+  \b Key \b Classes
+    - \ref Translate
+    - \ref AssemblyEmit
+    - \ref PcodeEmit
+    - \ref LoadImage
+    - \ref ContextDatabase
+
+  \section sleighoverview Overview
+
+  Welcome to \b SLEIGH, a machine language translation and
+  dissassembly engine.  SLEIGH is both a processor
+  specification language and the associated library and
+  tools for using such a specification to generate assembly
+  and to generate \b pcode, a reverse engineering Register
+  Transfer Language (RTL), from binary machine instructions.
+  
+  SLEIGH was originally based on \b SLED, a
+  \e Specification \e Language \e for \e Encoding \e and
+  \e Decoding, designed by Norman Ramsey and Mary F. Fernandez,
+  which performed disassembly (and assembly).  SLEIGH
+  extends SLED by providing semantic descriptions (via the
+  RTL) of machine instructions and other practical enhancements
+  for doing real world reverse engineering. 
+
+  SLEIGH is part of Project \b GHIDRA. It provides the core
+  of the GHIDRA disassembler and the data-flow and
+  decompilation analysis.  However, SLEIGH can serve as a
+  standalone library for use in other applications for
+  providing a generic disassembly and RTL translation interface.
+
+  \section sleighbuild Building SLEIGH
+
+  There are a couple of \e make targets for building the SLEIGH
+  library from source.  These are:
+
+  \code
+     make libsla.a               # Build the main library
+
+     make libsla_dbg.a           # Build the library with debug symbols
+  \endcode
+
+  The source code file \e sleighexample.cc has a complete example
+  of initializing the Translate engine and using it to generate
+  assembly and pcode.  The source has a hard-coded file name,
+  \e x86testcode, as the example binary executable it attempts
+  to decode, but this can easily be changed.  It also needs
+  a SLEIGH specification file (\e .sla) to be present.
+
+  Building the example application can be done with something
+  similar to the following makefile fragment.
+
+  \code
+    # The C compiler
+    CXX=g++
+
+    # Debug flags
+    DBG_CXXFLAGS=-g -Wall -Wno-sign-compare
+
+    OPT_CXXFLAGS=-O2 -Wall -Wno-sign-compare
+
+    # libraries
+    INCLUDES=-I./src
+
+    LNK=src/libsla_dbg.a
+
+    sleighexample.o:      sleighexample.cc
+          $(CXX) -c $(DBG_CXXFLAGS) -o sleighexample sleighexample.o $(LNK)
+  
+    clean:
+          rm -rf *.o sleighexample
+  \endcode
+
+  \section sleighuse Using SLEIGH
+
+  SLEIGH is a generic reverse engineering tool in the sense
+  that the API is designed to be completely processor
+  independent.  In order to process binary executables for a
+  specific processor, The library reads in a \e
+  specification \e file, which describes how instructions
+  are encoded and how they are interpreted by the processor.
+  An application which needs to do disassembly or generate
+  \b pcode can design to the SLEIGH API once, and then the
+  application will automatically support any processor for
+  which there is a specification.
+  
+  For working with a single processor, the SLEIGH library
+  needs to load a single \e compiled form of the processor
+  specification, which is traditionally given a ".sla" suffix.
+  Most common processors already have a ".sla" file available.
+  So to use SLEIGH with these processors, the library merely
+  needs to be made aware of the desired file.  This documentation
+  covers the use of the SLEIGH API, assuming that this
+  specification file is available.
+
+  The ".sla" files themselves are created by running
+  the \e compiler on a file written in the formal SLEIGH
+  language.  These files traditionally have the suffix ".slaspec"
+  For those who want to design such a specification for a new
+  processor, please refer to the document, "SLEIGH: A Language
+  for Rapid Processor Specification."
+
+ */
+
+ /**
+  \page sleighAPIbasic The Basic SLEIGH Interface
+
+  To use SLEIGH as a library within an application, there
+  are basically five classes that you need to be aware of.
+
+    - \ref sleightranslate
+    - \ref sleighassememit
+    - \ref sleighpcodeemit
+    - \ref sleighloadimage
+    - \ref sleighcontext
+      
+  \section sleightranslate Translate (or Sleigh)
+
+  The core SLEIGH class is Sleigh, which is derived from the
+  interface, Translate.  In order to instantiate it in your code,
+  you need a LoadImage object, and a ContextDatabase object.
+  The load image is responsible for retrieving instruction
+  bytes, based on address, from a binary executable. The context
+  database provides the library extra mode information that may
+  be necessary to do the disassembly or translation.  This can
+  be used, for instance, to specify that an x86 binary is running
+  in 32-bit mode, or to specify that an ARM processor is running
+  in THUMB mode.  Once these objects are built, the Sleigh
+  object can be immediately instantiated.
+
+  \code
+  LoadImageBfd *loader;
+  ContextDatabase *context;
+  Translate *trans;
+
+  // Set up the loadimage
+  // Providing an executable name and architecture
+  string loadimagename = "x86testcode";
+  string bfdtarget= "default";
+
+  loader = new LoadImageBfd(loadimagename,bfdtarget);
+  loader->open();       // Load the executable from file
+
+  context = new ContextInternal();   // Create a processor context
+
+  trans = new Sleigh(loader,context);  // Instantiate the translator
+  \endcode
+
+  Once the Sleigh object is in hand, the only required
+  initialization step left is to inform it of the ".sla" file.
+  The file is in XML format and needs to be read in using
+  SLEIGH's built-in XML parser. The following code accomplishes
+  this.
+
+  \code
+  string sleighfilename = "specfiles/x86.sla";
+  DocumentStorage docstorage;
+  Element *sleighroot = docstorage.openDocument(sleighfilename)->getRoot();
+  docstorage.registerTag(sleighroot);
+  trans->initialize(docstorage);  // Initialize the translator
+  \endcode
+
+  \section sleighassememit AssemblyEmit
+
+  In order to do disassembly, you need to derive a class from
+  AssemblyEmit, and implement the method \e dump.  The library
+  will call this method exactly once, for each instruction
+  disassembled.
+
+  This routine simply needs to decide how (and where) to print
+  the corresponding portion of the disassembly.  For instance,
+
+  \code
+  class AssemblyRaw : public AssemblyEmit {
+  public:
+    virtual void dump(const Address &addr,const string &mnem,const string &body) {
+      addr.printRaw(cout);
+      cout << ": " << mnem << ' ' << body << endl;
+    }
+  };
+  \endcode
+
+  This is a minimal implementation that simply dumps the
+  disassembly straight to standard out.  Once this object is
+  instantiated, the Sleigh object can use it to write out
+  assembly via the Translate::printAssembly() method.
+
+  \code
+  AssemblyEmit *assememit = new AssemblyRaw();
+
+  Address addr(trans->getDefaultCodeSpace(),0x80484c0);
+  int4 length;                  // Length of instruction in bytes
+
+  length = trans->printAssembly(*assememit,addr);
+  addr = addr + length;        // Advance to next instruction
+  length = trans->printAssembly(*assememit,addr);
+  addr = addr + length;
+  length = trans->printAssembly(*assememit,addr);
+  \endcode
+
+  \section sleighpcodeemit PcodeEmit
+
+  In order to generate a \b pcode translation of a machine
+  instruction, you need to derive a class from PcodeEmit and
+  implement the virtual method \e dump. This method will be
+  invoked once for each \b pcode operation in the translation
+  of a machine instruction.  There will likely be multiple calls
+  per instruction.  Each call passes in a single \b pcode
+  operation, complete with its possible varnode output, and
+  all of its varnode inputs.  Here is an example of a PcodeEmit
+  object that simply prints out the \b pcode.
+
+  \code
+  class PcodeRawOut : public PcodeEmit {
+  public:
+    virtual void dump(const Address &addr,OpCode opc,VarnodeData *outvar,VarnodeData *vars,int4 isize);
+  };
+
+  static void print_vardata(ostream &s,VarnodeData &data)
+
+  {
+    s << '(' << data.space->getName() << ',';
+    data.space->printOffset(s,data.offset);
+    s << ',' << dec << data.size << ')';
+  }
+
+  void PcodeRawOut::dump(const Address &addr,OpCode opc,VarnodeData *outvar,VarnodeData *vars,int4 isize)
+
+  {
+    if (outvar != (VarnodeData *)0) {     // The output is optional
+      print_vardata(cout,*outvar);
+      cout << " = ";
+    }
+    cout << get_opname(opc);
+    // Possibly check for a code reference or a space reference
+    for(int4 i=0;i<isize;++i) {
+      cout << ' ';
+      print_vardata(cout,vars[i]);
+    }
+    cout << endl;
+  }
+  \endcode
+
+  Notice that the \e dump routine uses the built-in function
+  \e get_opname to find a string version of the opcode.  Each
+  varnode is defined in terms of the VarnodeData object, which
+  is defined simply:
+
+  \code
+  struct VarnodeData {
+    AddrSpace *space;          // The address space
+    uintb offset;              // The offset within the space
+    uint4 size;                // The number of bytes at that location
+  };
+  \endcode
+
+  Once the PcodeEmit object is instantiated, the Sleigh object can
+  use it to generate pcode, one instruction at a time, using the
+  Translate::oneInstruction() const method.
+
+  \code
+  PcodeEmit *pcodeemit = new PcodeRawOut();
+
+  Address addr(trans->getDefaultCodeSpace(),0x80484c0);
+  int4 length;                   // Length of instruction in bytes
+
+  length = trans->oneInstruction(*pcodeemit,addr);
+  addr = addr + length;         // Advance to next instruction
+  length = trans->oneInstruction(*pcodeemit,addr);
+  addr = addr + length;
+  length = trans->oneInstruction(*pcodeemit,addr);
+  \endcode
+
+  For an application to properly \e follow \e flow, while translating
+  machine instructions into pcode, the emitted pcode must be
+  inspected for the various branch operations.
+
+  \section sleighloadimage LoadImage
+
+  A LoadImage holds all the binary data from an executable file
+  in the format similar to how it would exist when being executed
+  by a real processor.  The interface to this from SLEIGH is
+  actually very simple, although it can hide a complicated
+  structure.  One method does most of the work, LoadImage::loadFill().
+  It takes a byte pointer, a size, and an Address. The method
+  is expected to fill in the \e ptr array with \e size bytes
+  taken from the load image, corresponding to the address \e addr.
+  There are two more virtual methods that are required for a
+  complete implementation of LoadImage, \e getArchType and
+  \e adjustVma, but these do not need to be implemented fully.
+
+  \code
+  class MyLoadImage : public LoadImage {
+  public:
+    MyLoadImage(const string &nm) : Loadimage(nm) {}
+    virtual void loadFill(uint1 *ptr,int4 size,const Address &addr);
+    virtual string getArchType(void) const { return "mytype"; }
+    virtual void adjustVma(long adjust) {}
+  };
+  \endcode
+
+  \section sleighcontext ContextDatabase
+
+  The ContextDatabase needs to keep track of any possible
+  context variable and its value, over different address ranges.
+  In most cases, you probably don't need to override the class
+  yourself, but can use the built-in class, ContextInternal.
+  This provides the basic functionality required and will work
+  for different architectures.  What you may need to do is
+  set values for certain variables, depending on the processor
+  and the environment it is running in.  For instance, for
+  the x86 platform, you need to set the \e addrsize and \e opsize
+  bits, to indicate the processor would be running in 32-bit
+  mode.  The context variables specific to a particular processor
+  are established by the SLEIGH spec.  So the variables can
+  only be set \e after the spec has been loaded.
+
+  \code
+    ...
+    context = new ContextInternal();
+    trans = new Sleigh(loader,context);
+    DocumentStorage docstorage;
+    Element *root = docstorage.openDocument("specfiles/x86.sla")->getRoot();
+    docstorage.registerTag(root);
+    trans->initialize(docstorage);
+
+    context->setVariableDefault("addrsize",1);  // Address size is 32-bits
+    context->setVariableDefault("opsize",1);    // Operand size is 32-bits
+  \endcode
+
+  
+ */
+#endif

--- a/src/worker/ghidra/sleighMishegos.hh
+++ b/src/worker/ghidra/sleighMishegos.hh
@@ -30,17 +30,17 @@ class SleighMishegos : public SleighBase {
   void clearForDelete(void);		///< Delete the context and disassembly caches
 protected:
   ParserContext *obtainContext(const Address &addr,int4 state) const;
-  void resolve(ParserContext &pos) const;	///< Generate a parse tree suitable for disassembly
-  void resolveHandles(ParserContext &pos) const;	///< Prepare the parse tree for p-code generation
+  void resolve(ParserContext &pc) const;	///< Generate a parse tree suitable for disassembly
+  void resolveHandles(ParserContext &pc) const;	///< Prepare the parse tree for p-code generation
 public:
   SleighMishegos(LoadImage *ld,ContextDatabase *c_db);		///< Constructor
-  virtual ~SleighMishegos(void);				///< Destructor
+  ~SleighMishegos(void) override;				///< Destructor
   void reset(LoadImage *ld,ContextDatabase *c_db);	///< Reset the engine for a new program
-  virtual void initialize(DocumentStorage &store);
-  virtual void registerContext(const string &name,int4 sbit,int4 ebit);
-  virtual void setContextDefault(const string &nm,uintm val);
-  virtual void allowContextSet(bool val) const;
-  virtual int4 instructionLength(const Address &baseaddr) const;
-  virtual int4 oneInstruction(PcodeEmit &emit,const Address &baseaddr) const;
-  virtual int4 printAssembly(AssemblyEmit &emit,const Address &baseaddr) const;
+  void initialize(DocumentStorage &store) override;
+  void registerContext(const string &name,int4 sbit,int4 ebit) override;
+  void setContextDefault(const string &nm,uintm val) override;
+  void allowContextSet(bool val) const override;
+  int4 instructionLength(const Address &baseaddr) const override;
+  int4 oneInstruction(PcodeEmit &emit, const Address &baseaddr) const override;
+  int4 printAssembly(AssemblyEmit &emit, const Address &baseaddr) const override;
 };

--- a/workers.spec
+++ b/workers.spec
@@ -8,3 +8,4 @@
 ./src/worker/bddisasm/bddisasm.so
 ./src/worker/iced/iced.so
 ./src/worker/yaxpeax-x86/libyaxpeax_x86_mishegos.so
+./src/worker/ghidra/ghidra.so


### PR DESCRIPTION
This contribution uses the [Lifting Bits Sleigh CMake project](https://github.com/lifting-bits/sleigh) to manage the build of Ghidra's Sleigh disassembler.

~I'm not sure if Ghidra's disassembly listing needs normalized in any way, but Ghidra uses all capital letters for the disassembled instruction.~ This doesn't seem to matter, only the number of characters for disassembly string matters

The implementation of the sleigh worker required modifying the upstream-provided disassembler to support single-shot disassembly at the same address. It was mostly just removing the caching mechanism, but the way the disassembler was coded, it required copying quite a bit instead of some other minimal way (like a flag or override) to disable it.

The `sleighMishegos.{cc,hh}` files were copied from upstream and you can view their diff like so, from the ghidra worker directory (check the file comments for the exact commit that was used as a baseline, since the `ghidra` submodule will be continuously updated):
```
vim -d sleighMishegos.cc ./ghidra/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh.cc
vim -d sleighMishegos.hh ./ghidra/Ghidra/Features/Decompiler/src/decompile/cpp/sleigh.hh
```

The `ghidra.cc` file also has a few copied functions from Ghidra's `sleighexample.cc` file for initializing sleigh.

TODO PR Merges:

- [x] https://github.com/lifting-bits/sleigh/pull/15
- [x] https://github.com/lifting-bits/sleigh/pull/16
- [x] https://github.com/lifting-bits/sleigh/pull/17