### PR TITLE
Build bddisasm using CMake

### DIFF
--- a/src/worker/bddisasm/Makefile
+++ b/src/worker/bddisasm/Makefile
@@ -1,17 +1,18 @@
 override CPPFLAGS := $(CPPFLAGS) -Ibddisasm/inc
-override LDFLAGS := $(LDFLAGS) -Lbddisasm/bin/x64/Release
+override LDFLAGS := $(LDFLAGS) -Lbddisasm/build
 override LDLIBS := $(LDLIBS) -lbddisasm
 
 .PHONY: all
 all: bddisasm.so
 
-bddisasm/bin/x64/Release/bddisasm.a:
-	$(MAKE) -C bddisasm bddisasm
+bddisasm/build/bddisasm.a:
+	cmake -B bddisasm/build -S bddisasm -DCMAKE_BUILD_TYPE=Release -DBDD_INCLUDE_TOOL=OFF -DBDD_INCLUDE_ISAGENERATOR=OFF
+	cmake --build bddisasm/build --target bddisasm --parallel
 
-bddisasm.so: bddisasm/bin/x64/Release/bddisasm.a bddisasm.o
+bddisasm.so: bddisasm/build/bddisasm.a bddisasm.o
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) bddisasm.o $(LDLIBS) -o $@
 
 .PHONY: clean
 clean:
-	$(MAKE) -C bddisasm clean
+	rm -rf bddisasm/build
 	rm -rf *.o *.so

--- a/src/worker/bddisasm/bddisasm.c
+++ b/src/worker/bddisasm/bddisasm.c
@@ -4,17 +4,6 @@
 
 char *worker_name = "bddisasm";
 
-/* This is used by NdToText. */
-int nd_vsnprintf_s(char *buffer, size_t sizeOfBuffer, size_t count, const char *format,
-                   va_list argptr) {
-  return vsnprintf(buffer, sizeOfBuffer, format, argptr);
-}
-
-/* This is used by NdDecode. */
-void *nd_memset(void *s, int c, size_t n) {
-  return memset(s, c, n);
-}
-
 static const char *bddisasm_strerror(NDSTATUS ndstatus) {
   switch (ndstatus) {
   case ND_STATUS_BUFFER_TOO_SMALL: {


### PR DESCRIPTION
This changes the bddisasm build to CMake. This should avoid issues like bitdefender/bddisasm#53 in the future. As I mentioned in that issue, we no longer use make as our build system, but the Makefile was not removed from the repository.

On top of that, `nd_vsnprintf_s` and `nd_memset` are now implemented in `bddisasm` by default so I removed them from the worker.
