### PR TITLE
Make HTML table header sticky when scrolling

### DIFF
--- a/src/mishmat/mishmat
+++ b/src/mishmat/mishmat
@@ -30,6 +30,12 @@ HEADER = ERB.new <<~HTML
         th, td {
           text-align: left;
         }
+
+        th {
+          position: sticky;
+          top: 0;
+          background: white;
+        }
       </style>
     </head>
 
@@ -53,12 +59,12 @@ HTML
 
 HEADER_ROWS = ERB.new <<~HTML
   <tr>
-    <th>input</th>
+    <th></th>
     <th colspan="100">worker</th>
   </tr>
 
   <tr>
-    <th></th>
+    <th>input</th>
     <% row[:outputs].each do |col| %>
       <th>
         <%= col[:worker_so] %>


### PR DESCRIPTION
The header for the results table does not disappear when scrolling
anymore. This is a much better user experience if you are unable to
remember the order of all workers when inspecting the HTML page.

Also moved the `input` text header to the same row as the worker list
so that it does not disappear like `worker` does. This is really a
workaround for my lack of knowledge in HTML/CSS for stickying two
rows...