### PR TITLE
Add LLVM worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           ruby \
           autotools-dev \
           autoconf \
+          llvm-dev \
           libtool
 
         sudo update-alternatives --install /usr/bin/python python /usr/bin/python2 1

--- a/src/worker/Makefile
+++ b/src/worker/Makefile
@@ -8,7 +8,8 @@ WORKERS = bfd \
 	bddisasm \
 	iced \
 	yaxpeax-x86 \
-	ghidra
+	ghidra \
+	llvm
 
 .PHONY: all
 all: worker $(WORKERS)

--- a/src/worker/llvm/Makefile
+++ b/src/worker/llvm/Makefile
@@ -1,0 +1,15 @@
+LLVM_CONFIG=llvm-config
+override CPPFLAGS := $(CPPFLAGS) $(shell $(LLVM_CONFIG) --cppflags)
+override LDFLAGS := $(LDFLAGS) $(shell $(LLVM_CONFIG) --ldflags) -Wl,-z,defs
+override LDLIBS := $(LDLIBS) $(shell $(LLVM_CONFIG) --libs)
+
+.PHONY: all
+all: llvm.so
+
+llvm.so: llvm.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $< $(LDLIBS) -o $@
+
+.PHONY: clean
+clean:
+	rm -rf *.o *.so
+

--- a/src/worker/llvm/llvm.c
+++ b/src/worker/llvm/llvm.c
@@ -1,0 +1,39 @@
+#include <llvm-c/Disassembler.h>
+#include <llvm-c/Target.h>
+
+#include "../worker.h"
+
+static LLVMDisasmContextRef dis;
+
+char *worker_name = "llvm";
+
+void worker_ctor() {
+  LLVMInitializeX86TargetInfo();
+  LLVMInitializeX86Target();
+  LLVMInitializeX86TargetMC();
+  LLVMInitializeX86Disassembler();
+  dis = LLVMCreateDisasm("x86_64-linux-gnu", NULL, 0, NULL, NULL);
+  if (!dis) {
+    errx(1, "LLVMCreateDisasm");
+  }
+  // Hex immediates and Intel syntax
+  // The first option doesn't seem to have an effect, though.
+  if (!LLVMSetDisasmOptions(dis, LLVMDisassembler_Option_PrintImmHex |
+                                     LLVMDisassembler_Option_AsmPrinterVariant))
+    errx(1, "LLVMSetDisasmOptions");
+}
+
+void worker_dtor() {
+  LLVMDisasmDispose(dis);
+}
+
+void try_decode(decode_result *result, uint8_t *raw_insn, uint8_t length) {
+  size_t len = LLVMDisasmInstruction(dis, raw_insn, length, 0, result->result, MISHEGOS_DEC_MAXLEN);
+  if (len > 0) {
+    result->status = S_SUCCESS;
+    result->len = strlen(result->result);
+    result->ndecoded = len;
+  } else {
+    result->status = S_FAILURE;
+  }
+}

--- a/workers.spec
+++ b/workers.spec
@@ -9,3 +9,4 @@
 ./src/worker/iced/iced.so
 ./src/worker/yaxpeax-x86/libyaxpeax_x86_mishegos.so
 ./src/worker/ghidra/ghidra.so
+./src/worker/llvm/llvm.so


### PR DESCRIPTION
LLVM has its own integrated disassembler. I use the system-provided LLVM instead of adding a submodule, as LLVM is fairly time-consuming to build.